### PR TITLE
infra: add bot contract (schema, Copilot instructions, validator, auto-merge)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# Copilot instructions — Dreamcobots
+
+You are contributing bots to **Dreamcobots**, a parallel bot factory. Every PR must follow the **bot contract** so it merges without conflicts.
+
+## The one rule
+
+**One PR = one new folder under `bots/<name>/` = one `bot.manifest.json`. Never touch shared files.**
+
+## What "shared files" means (do not edit)
+
+- Workflows (`.github/workflows/**`)
+- Registries, catalogues, or aggregator files at the repo root
+- Other bots under `bots/**` (different folder)
+- The schema file `bot.manifest.schema.json`
+- Top-level config (`package.json`, `pyproject.toml`, `requirements.txt`, `pnpm-workspace.yaml`)
+
+If you believe a shared file genuinely needs to change, open a separate PR labeled `infra` and explain why. CI will block any non-`infra` PR that touches shared files.
+
+## Template for a new bot
+
+```
+bots/<new_bot_name>/
+├── bot.manifest.json    # REQUIRED, validates against ../../bot.manifest.schema.json
+├── README.md            # what the bot does, how to run it
+└── src/                 # bot code (any language matching entrypoint.runtime)
+```
+
+### `bot.manifest.json` minimal example
+
+```json
+{
+  "manifestVersion": "1",
+  "name": "my_new_bot",
+  "displayName": "My New Bot",
+  "description": "One-sentence description of what this bot does for the user.",
+  "division": "DreamSalesPro",
+  "tier": "PRO",
+  "category": "Lead Generation",
+  "capabilities": ["scrape_linkedin", "enrich_email"],
+  "entrypoint": {
+    "runtime": "python",
+    "command": "python -m my_new_bot.main",
+    "workdir": "src"
+  },
+  "revenueModel": { "type": "subscription", "targetMrr": 2500, "currency": "USD" },
+  "dependencies": ["requests", "beautifulsoup4"],
+  "owner": { "team": "DreamSalesPro", "githubHandles": ["@your-handle"] },
+  "status": "draft",
+  "tags": ["b2b", "outbound"]
+}
+```
+
+Allowed `division` values: `DreamRealEstate`, `DreamSalesPro`, `DreamFinance`, `DreamAI`, `DreamSoft`, `DreamGov`, `DreamMedia`, `DreamOps`.
+
+## Why this matters
+
+The Command Center auto-discovers bots by reading their `bot.manifest.json`. When you follow this contract:
+
+- Your PR merges automatically the moment it passes validation.
+- Your bot shows up in `/bots` and `/divisions` with no follow-up work.
+- You never collide with another Copilot PR.
+
+If you violate the contract, the `validate-bot-pr` check fails and you'll be asked to rewrite. Don't try to be clever — the lane is narrow on purpose.

--- a/.github/workflows/auto-merge-intake.yml
+++ b/.github/workflows/auto-merge-intake.yml
@@ -1,0 +1,86 @@
+name: auto-merge-intake
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
+  check_suite:
+    types: [completed]
+  workflow_run:
+    workflows: [validate-bot-pr]
+    types: [completed]
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: "open", per_page: 100,
+            });
+
+            for (const pr of prs) {
+              if (pr.draft) continue;
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: pr.number, per_page: 100,
+              });
+              const dirs = new Set();
+              let touchedNonBot = false;
+              let manifestPresent = false;
+              for (const f of files) {
+                if (!f.filename.startsWith("bots/")) {
+                  touchedNonBot = true;
+                  continue;
+                }
+                const parts = f.filename.split("/");
+                if (parts[1]) dirs.add(parts[1]);
+                if (parts[parts.length - 1] === "bot.manifest.json") manifestPresent = true;
+              }
+              if (touchedNonBot || dirs.size !== 1 || !manifestPresent) {
+                core.info(`PR #${pr.number} skipped (not a clean single-bot intake).`);
+                continue;
+              }
+
+              // Must be a NEW folder (no files in that dir on main yet)
+              const dir = [...dirs][0];
+              let isNew = true;
+              try {
+                await github.rest.repos.getContent({ owner, repo, path: `bots/${dir}` });
+                isNew = false;
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+              if (!isNew) {
+                core.info(`PR #${pr.number} skipped (modifies existing bot ${dir}).`);
+                continue;
+              }
+
+              // Wait for validate-bot-pr to be green
+              const checks = await github.rest.checks.listForRef({
+                owner, repo, ref: pr.head.sha,
+              });
+              const validate = checks.data.check_runs.find(
+                (c) => c.name === "validate" || c.name === "validate-bot-pr"
+              );
+              if (!validate || validate.conclusion !== "success") {
+                core.info(`PR #${pr.number} skipped (validate check not green).`);
+                continue;
+              }
+
+              try {
+                await github.rest.pulls.merge({
+                  owner, repo, pull_number: pr.number, merge_method: "squash",
+                });
+                core.info(`PR #${pr.number} auto-merged (new bot: ${dir}).`);
+              } catch (err) {
+                core.warning(`PR #${pr.number} merge failed: ${err.message}`);
+              }
+            }

--- a/.github/workflows/validate-bot-pr.yml
+++ b/.github/workflows/validate-bot-pr.yml
@@ -1,0 +1,75 @@
+name: validate-bot-pr
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changes
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed.txt
+          echo "Changed files:"
+          cat /tmp/changed.txt
+
+      - name: Enforce one-folder rule
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'infra') }}
+        run: |
+          set -e
+          NON_BOT=$(grep -v '^bots/' /tmp/changed.txt || true)
+          if [ -n "$NON_BOT" ]; then
+            echo "::error::PR touches shared files. Label 'infra' is required for non-bot changes."
+            echo "$NON_BOT"
+            exit 1
+          fi
+          DIRS=$(awk -F/ '/^bots\//{print $2}' /tmp/changed.txt | sort -u)
+          COUNT=$(echo "$DIRS" | grep -c . || true)
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error::PR must touch exactly one bots/<name>/ directory (touched: $COUNT)"
+            echo "$DIRS"
+            exit 1
+          fi
+          echo "BOT_DIR=$DIRS" >> "$GITHUB_ENV"
+
+      - name: Setup Node
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'infra') }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Validate manifest
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'infra') }}
+        run: |
+          set -e
+          MANIFEST="bots/$BOT_DIR/bot.manifest.json"
+          if [ ! -f "$MANIFEST" ]; then
+            echo "::error::Missing $MANIFEST"
+            exit 1
+          fi
+          npm install --no-save ajv@8 ajv-formats@3
+          node -e "
+            const Ajv = require('ajv').default;
+            const addFormats = require('ajv-formats').default;
+            const fs = require('fs');
+            const schema = JSON.parse(fs.readFileSync('bot.manifest.schema.json','utf8'));
+            const data = JSON.parse(fs.readFileSync(process.env.MANIFEST,'utf8'));
+            const ajv = new Ajv({allErrors:true, strict:false});
+            addFormats(ajv);
+            const validate = ajv.compile(schema);
+            if (!validate(data)) {
+              console.error('Manifest invalid:', JSON.stringify(validate.errors, null, 2));
+              process.exit(1);
+            }
+            console.log('Manifest OK:', data.name);
+          "
+        env:
+          MANIFEST: bots/${{ env.BOT_DIR }}/bot.manifest.json

--- a/bot.manifest.schema.json
+++ b/bot.manifest.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dreamco.tech/schemas/bot.manifest.schema.json",
+  "title": "DreamCo Bot Manifest",
+  "description": "Source of truth describing a single bot. Each bot lives in bots/<name>/ and MUST ship a bot.manifest.json that validates against this schema.",
+  "type": "object",
+  "required": [
+    "manifestVersion",
+    "name",
+    "description",
+    "division",
+    "tier",
+    "category",
+    "entrypoint",
+    "owner"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "manifestVersion": { "const": "1" },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
+    "displayName": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "description": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "division": {
+      "type": "string",
+      "enum": [
+        "DreamRealEstate",
+        "DreamSalesPro",
+        "DreamFinance",
+        "DreamAI",
+        "DreamSoft",
+        "DreamGov",
+        "DreamMedia",
+        "DreamOps"
+      ]
+    },
+    "tier": { "type": "string", "enum": ["FREE", "PRO", "ENTERPRISE"] },
+    "category": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "capabilities": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+    "entrypoint": {
+      "type": "object",
+      "required": ["runtime", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "runtime": {
+          "type": "string",
+          "enum": ["python", "node", "bun", "deno", "container"]
+        },
+        "command": { "type": "string", "minLength": 1 },
+        "workdir": { "type": "string" }
+      }
+    },
+    "revenueModel": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["subscription", "usage", "one_time", "commission", "internal"]
+        },
+        "targetMrr": { "type": "number", "minimum": 0 },
+        "currency": { "type": "string", "minLength": 3, "maxLength": 3 }
+      }
+    },
+    "dependencies": { "type": "array", "items": { "type": "string" } },
+    "owner": {
+      "type": "object",
+      "required": ["team"],
+      "additionalProperties": false,
+      "properties": {
+        "team": { "type": "string", "minLength": 1 },
+        "githubHandles": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "paused", "deprecated"]
+    },
+    "tags": { "type": "array", "items": { "type": "string" } }
+  }
+}


### PR DESCRIPTION
Adds the foundational bot contract that the parallel build system depends on.

## Files added
- `bot.manifest.schema.json` — JSON Schema for `bots/<name>/bot.manifest.json`
- `.github/copilot-instructions.md` — instructions Copilot follows when opening bot PRs
- `.github/workflows/validate-bot-pr.yml` — validator check that runs on each bot PR
- `.github/workflows/auto-merge-intake.yml` — auto-merges clean, single-folder, schema-valid bot PRs

## Why
Without these, Copilot has no instructions, no validator, and no auto-merge — so the parallel bot build system isn't live. The Command Center's `lib/db` Zod schema mirrors `bot.manifest.schema.json`; they must stay in lockstep.

## Follow-up PRs
Six per-bot PRs will follow, each adding a single `bots/<name>/` folder that the validator + auto-merge will land automatically.