### PR TITLE
bot: add ai_enablement_hub

### DIFF
--- a/bots/ai_enablement_hub/README.md
+++ b/bots/ai_enablement_hub/README.md
@@ -1,0 +1,8 @@
+# AI Enablement Hub
+
+Revived from PR #344. Provides centralized AI model routing, prompt registry, and per-tier usage metering for every DreamCo bot.
+
+## Endpoints
+- `POST /v1/complete` — tier-gated chat completion
+- `GET /v1/prompts/:slug` — fetch a registered prompt
+- `GET /v1/usage` — current account usage and remaining quota

--- a/bots/ai_enablement_hub/bot.manifest.json
+++ b/bots/ai_enablement_hub/bot.manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifestVersion": "1",
+  "name": "ai_enablement_hub",
+  "displayName": "AI Enablement Hub",
+  "description": "Central hub that enables, gates, and meters AI capabilities across all DreamCo bots (model routing, prompt registry, usage caps).",
+  "division": "DreamAI",
+  "tier": "ENTERPRISE",
+  "category": "AI Research",
+  "capabilities": [
+    "model_routing",
+    "prompt_registry",
+    "usage_metering",
+    "tier_enforcement"
+  ],
+  "entrypoint": {
+    "runtime": "python",
+    "command": "python -m ai_enablement_hub.server",
+    "workdir": "src"
+  },
+  "revenueModel": { "type": "internal", "currency": "USD" },
+  "dependencies": ["fastapi", "uvicorn", "httpx", "redis"],
+  "owner": { "team": "DreamAI", "githubHandles": [] },
+  "status": "draft",
+  "tags": ["platform", "ai", "metering", "revived-pr-344"]
+}


### PR DESCRIPTION
Adds the `bots/ai_enablement_hub/` folder verbatim from the Command Center contract staging directory.

Single-folder PR with a valid `bot.manifest.json` — the `validate-bot-pr` check should pass and `auto-merge-intake` should land it automatically.