### PR TITLE
bot: add elite_scraper

### DIFF
--- a/bots/elite_scraper/README.md
+++ b/bots/elite_scraper/README.md
@@ -1,0 +1,3 @@
+# Elite Scraper
+
+Revived from PR #303. Headless-browser scraper with proxy rotation and structured contact extraction. Feeds the CompanyLookup and AutoClientHunter bots.

--- a/bots/elite_scraper/bot.manifest.json
+++ b/bots/elite_scraper/bot.manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifestVersion": "1",
+  "name": "elite_scraper",
+  "displayName": "Elite Scraper",
+  "description": "High-throughput, residential-proxied scraper that pulls structured B2B contact data from public web sources.",
+  "division": "DreamSalesPro",
+  "tier": "PRO",
+  "category": "Lead Generation",
+  "capabilities": ["scrape_web", "extract_contacts", "rotate_proxies", "respect_robots"],
+  "entrypoint": {
+    "runtime": "python",
+    "command": "python -m elite_scraper.worker",
+    "workdir": "src"
+  },
+  "revenueModel": { "type": "subscription", "targetMrr": 8000, "currency": "USD" },
+  "dependencies": ["playwright", "httpx", "lxml", "pydantic"],
+  "owner": { "team": "DreamSalesPro", "githubHandles": [] },
+  "status": "draft",
+  "tags": ["scraping", "leads", "revived-pr-303"]
+}


### PR DESCRIPTION
Adds the `bots/elite_scraper/` folder verbatim from the Command Center contract staging directory.

Single-folder PR with a valid `bot.manifest.json` — the `validate-bot-pr` check should pass and `auto-merge-intake` should land it automatically.