### PR TITLE
bot: add company_lookup

### DIFF
--- a/bots/company_lookup/README.md
+++ b/bots/company_lookup/README.md
@@ -1,0 +1,3 @@
+# Company Lookup
+
+Revived from PR #341. Lightweight HTTP API that takes a domain and returns firmographics, tech stack, and likely decision-maker emails.

--- a/bots/company_lookup/bot.manifest.json
+++ b/bots/company_lookup/bot.manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifestVersion": "1",
+  "name": "company_lookup",
+  "displayName": "Company Lookup",
+  "description": "Enrich a domain or company name into a full firmographic + technographic profile (size, industry, stack, decision makers).",
+  "division": "DreamSalesPro",
+  "tier": "PRO",
+  "category": "Lead Generation",
+  "capabilities": ["enrich_company", "detect_tech_stack", "find_decision_makers"],
+  "entrypoint": {
+    "runtime": "node",
+    "command": "node dist/index.js",
+    "workdir": "src"
+  },
+  "revenueModel": { "type": "usage", "targetMrr": 5000, "currency": "USD" },
+  "dependencies": ["axios", "cheerio", "zod"],
+  "owner": { "team": "DreamSalesPro", "githubHandles": [] },
+  "status": "draft",
+  "tags": ["enrichment", "b2b", "revived-pr-341"]
+}


### PR DESCRIPTION
Adds the `bots/company_lookup/` folder verbatim from the Command Center contract staging directory.

Single-folder PR with a valid `bot.manifest.json` — the `validate-bot-pr` check should pass and `auto-merge-intake` should land it automatically.