### PR TITLE
bot: add god_mode_autocloser

### DIFF
--- a/bots/god_mode_autocloser/README.md
+++ b/bots/god_mode_autocloser/README.md
@@ -1,0 +1,3 @@
+# God Mode AutoCloser
+
+Revived from PR #234. End-to-end autonomous closer that takes a qualified lead and books revenue without human handoff. Wires AutoClientHunter → AIEnablementHub → PaymentAutoCollector.

--- a/bots/god_mode_autocloser/bot.manifest.json
+++ b/bots/god_mode_autocloser/bot.manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifestVersion": "1",
+  "name": "god_mode_autocloser",
+  "displayName": "God Mode AutoCloser",
+  "description": "Autonomous sales closer — picks up qualified leads, runs the full nurture-to-checkout sequence, and books revenue without human touch.",
+  "division": "DreamSalesPro",
+  "tier": "ENTERPRISE",
+  "category": "Sales",
+  "capabilities": [
+    "qualify_lead",
+    "send_outreach",
+    "negotiate",
+    "checkout_handoff"
+  ],
+  "entrypoint": {
+    "runtime": "python",
+    "command": "python -m god_mode_autocloser.main",
+    "workdir": "src"
+  },
+  "revenueModel": { "type": "commission", "targetMrr": 25000, "currency": "USD" },
+  "dependencies": ["openai", "stripe", "fastapi"],
+  "owner": { "team": "DreamSalesPro", "githubHandles": [] },
+  "status": "draft",
+  "tags": ["sales", "autonomous", "revived-pr-234"]
+}


### PR DESCRIPTION
Adds the `bots/god_mode_autocloser/` folder verbatim from the Command Center contract staging directory.

Single-folder PR with a valid `bot.manifest.json` — the `validate-bot-pr` check should pass and `auto-merge-intake` should land it automatically.