### PR TITLE
bot: add auto_client_hunter

### DIFF
--- a/bots/auto_client_hunter/README.md
+++ b/bots/auto_client_hunter/README.md
@@ -1,0 +1,3 @@
+# Auto Client Hunter
+
+Revived from PR #240. Always-on prospect finder feeding the God Mode AutoCloser.

--- a/bots/auto_client_hunter/bot.manifest.json
+++ b/bots/auto_client_hunter/bot.manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifestVersion": "1",
+  "name": "auto_client_hunter",
+  "displayName": "Auto Client Hunter",
+  "description": "Continuously hunts new ICP-fit prospects across web, social, and signals, qualifies them, and pushes them into the closer pipeline.",
+  "division": "DreamSalesPro",
+  "tier": "PRO",
+  "category": "Lead Generation",
+  "capabilities": ["signal_detect", "icp_match", "auto_outreach"],
+  "entrypoint": {
+    "runtime": "python",
+    "command": "python -m auto_client_hunter.scheduler",
+    "workdir": "src"
+  },
+  "revenueModel": { "type": "subscription", "targetMrr": 12000, "currency": "USD" },
+  "dependencies": ["httpx", "pydantic", "celery"],
+  "owner": { "team": "DreamSalesPro", "githubHandles": [] },
+  "status": "draft",
+  "tags": ["prospecting", "automation", "revived-pr-240"]
+}


### PR DESCRIPTION
Adds the `bots/auto_client_hunter/` folder verbatim from the Command Center contract staging directory.

Single-folder PR with a valid `bot.manifest.json` — the `validate-bot-pr` check should pass and `auto-merge-intake` should land it automatically.