### PR TITLE
bot: add payment_autocollector

### DIFF
--- a/bots/payment_autocollector/README.md
+++ b/bots/payment_autocollector/README.md
@@ -1,0 +1,3 @@
+# Payment AutoCollector
+
+Revived from PR #234 cluster. Owns the full Stripe dunning + recovery loop so finance never manually chases failed invoices.

--- a/bots/payment_autocollector/bot.manifest.json
+++ b/bots/payment_autocollector/bot.manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifestVersion": "1",
+  "name": "payment_autocollector",
+  "displayName": "Payment AutoCollector",
+  "description": "Detects failed or delinquent invoices and auto-runs the dunning sequence (retry, email, alt-payment, recovery) end to end.",
+  "division": "DreamFinance",
+  "tier": "PRO",
+  "category": "Payments",
+  "capabilities": ["dunning", "card_retry", "alt_payment_route", "ledger_reconcile"],
+  "entrypoint": {
+    "runtime": "node",
+    "command": "node dist/worker.js",
+    "workdir": "src"
+  },
+  "revenueModel": { "type": "commission", "targetMrr": 9000, "currency": "USD" },
+  "dependencies": ["stripe", "drizzle-orm", "pino"],
+  "owner": { "team": "DreamFinance", "githubHandles": [] },
+  "status": "draft",
+  "tags": ["payments", "recovery", "revived-pr-234"]
+}


### PR DESCRIPTION
Adds the `bots/payment_autocollector/` folder verbatim from the Command Center contract staging directory.

Single-folder PR with a valid `bot.manifest.json` — the `validate-bot-pr` check should pass and `auto-merge-intake` should land it automatically.