### PR TITLE
Add secure Buddy token handoffs

### DIFF
--- a/config/buddy-connector-registry.json
+++ b/config/buddy-connector-registry.json
@@ -88,5 +88,17 @@
     {"id": "commerce", "label": "Commerce and payments", "minimum_scope": "read-only until transaction approval"},
     {"id": "media", "label": "Media and publishing", "minimum_scope": "draft and preview before publish"},
     {"id": "custom", "label": "Documented custom application", "minimum_scope": "sandbox before live access"}
-  ]
+  ],
+  "token_transfer": {
+    "mode": "reference_to_reference",
+    "status": "backend_vault_required",
+    "allowed_token_kinds": ["api_token", "oauth_access_token", "oauth_refresh_token"],
+    "blocked_token_kinds": ["browser_session_cookie", "identity_token", "payment_token", "recovery_code"],
+    "writable_destinations": ["os_keychain", "managed_vault"],
+    "max_plan_ttl_seconds": 300,
+    "same_audience_required": true,
+    "explicit_user_approval_required": true,
+    "one_time_execution": true,
+    "raw_tokens_accepted_in_public_clients": false
+  }
 }

--- a/dreamco_platform/connections/__init__.py
+++ b/dreamco_platform/connections/__init__.py
@@ -11,6 +11,9 @@ from .broker import (
     SecretReference,
     SignupPlan,
     SignupRequest,
+    TokenKind,
+    TokenTransferPlan,
+    TokenTransferRequest,
 )
 
 __all__ = [
@@ -24,4 +27,7 @@ __all__ = [
     "SecretReference",
     "SignupPlan",
     "SignupRequest",
+    "TokenKind",
+    "TokenTransferPlan",
+    "TokenTransferRequest",
 ]

--- a/dreamco_platform/connections/broker.py
+++ b/dreamco_platform/connections/broker.py
@@ -34,7 +34,14 @@ class AuthMethod(str, Enum):
     CUSTOM_REST = "custom_rest"
 
 
+class TokenKind(str, Enum):
+    API_TOKEN = "api_token"
+    OAUTH_ACCESS_TOKEN = "oauth_access_token"
+    OAUTH_REFRESH_TOKEN = "oauth_refresh_token"
+
+
 SECRET_PROVIDERS = {"environment", "os_keychain", "managed_vault"}
+WRITABLE_SECRET_PROVIDERS = {"os_keychain", "managed_vault"}
 SECRET_LOCATOR = re.compile(r"^[A-Za-z][A-Za-z0-9_.:/-]{2,127}$")
 TOKEN_LIKE = re.compile(
     r"(?:github_pat_|ghs_|(?:sk|rk)_(?:live|test)_|-----BEGIN .*PRIVATE KEY-----)",
@@ -194,6 +201,62 @@ class SignupPlan:
         }
 
 
+@dataclass(frozen=True)
+class TokenTransferRequest:
+    user_id: str
+    connector_id: str
+    token_kind: TokenKind
+    source_ref: SecretReference
+    destination_ref: SecretReference
+    source_audience: str
+    destination_audience: str
+    reason: str
+    scopes: tuple[str, ...] = ()
+    ttl_seconds: int = 120
+    explicit_user_approval: bool = False
+
+
+@dataclass
+class TokenTransferPlan:
+    transfer_id: str
+    connector_id: str
+    token_kind: str
+    status: str
+    audience: str
+    scopes: list[str]
+    reason: str
+    source_provider: str
+    destination_provider: str
+    created_at: float
+    expires_at: float
+    approval_gates: list[dict[str, Any]]
+    next_steps: list[str]
+    private_context: dict[str, str] = field(default_factory=dict, repr=False)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "schema": "dreamco.buddy_token_transfer.v1",
+            "transfer_id": self.transfer_id,
+            "connector_id": self.connector_id,
+            "token_kind": self.token_kind,
+            "status": self.status,
+            "audience": self.audience,
+            "scopes": self.scopes,
+            "reason": self.reason,
+            "source_provider": self.source_provider,
+            "destination_provider": self.destination_provider,
+            "source_reference_configured": True,
+            "destination_reference_configured": True,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "approval_gates": self.approval_gates,
+            "next_steps": self.next_steps,
+            "one_time": True,
+            "same_audience_required": True,
+            "raw_token_accepted": False,
+        }
+
+
 class BuddyConnectionBroker:
     """Prepare scoped app access while preserving user control."""
 
@@ -345,6 +408,73 @@ class BuddyConnectionBroker:
                 "User completes every identity, legal, security, and payment gate.",
                 "Buddy connects the approved account through the least-privilege auth method.",
             ],
+        )
+
+    def create_token_transfer_plan(self, request: TokenTransferRequest) -> TokenTransferPlan:
+        if not request.user_id.strip():
+            raise ConnectionBrokerError("A user id is required for the audit trail.")
+        if not re.fullmatch(r"[a-z][a-z0-9-]{2,63}", request.connector_id):
+            raise ConnectionBrokerError("Connector id must be a stable lowercase slug.")
+        request.source_ref.validate()
+        request.destination_ref.validate()
+        if request.destination_ref.provider not in WRITABLE_SECRET_PROVIDERS:
+            raise ConnectionBrokerError("Destination must be a writable keychain or managed vault.")
+        if request.source_ref == request.destination_ref:
+            raise ConnectionBrokerError("Source and destination references must be different.")
+        if not 30 <= request.ttl_seconds <= 300:
+            raise ConnectionBrokerError("Transfer plans must expire in 30 to 300 seconds.")
+        if len(request.reason.strip()) < 5:
+            raise ConnectionBrokerError("A clear transfer reason is required.")
+        if TOKEN_LIKE.search(request.reason) or re.search(r"[A-Za-z0-9_-]{32,}", request.reason):
+            raise ConnectionBrokerError("Transfer reason must not contain a token or credential value.")
+
+        source = urlsplit(_https_url(request.source_audience, "Source audience"))
+        destination = urlsplit(_https_url(request.destination_audience, "Destination audience"))
+        if source.query or source.fragment or destination.query or destination.fragment:
+            raise ConnectionBrokerError("Token audiences must not contain query parameters or fragments.")
+        source_origin = f"{source.scheme}://{source.netloc}"
+        destination_origin = f"{destination.scheme}://{destination.netloc}"
+        if source_origin != destination_origin:
+            raise ConnectionBrokerError(
+                "Tokens cannot move between app audiences; authorize the destination app separately."
+            )
+
+        scopes = list(dict.fromkeys(scope.strip() for scope in request.scopes if scope.strip()))
+        if any(not re.fullmatch(r"[A-Za-z0-9._:/-]{1,80}", scope) for scope in scopes):
+            raise ConnectionBrokerError("Token scopes contain unsupported characters.")
+
+        now = time.time()
+        approved = request.explicit_user_approval
+        return TokenTransferPlan(
+            transfer_id=f"transfer-{uuid.uuid4().hex[:16]}",
+            connector_id=request.connector_id,
+            token_kind=request.token_kind.value,
+            status="backend_vault_execution_required" if approved else "approval_required",
+            audience=source_origin,
+            scopes=scopes,
+            reason=request.reason.strip(),
+            source_provider=request.source_ref.provider,
+            destination_provider=request.destination_ref.provider,
+            created_at=now,
+            expires_at=now + request.ttl_seconds,
+            approval_gates=[
+                {
+                    "id": "explicit_token_transfer_approval",
+                    "reason": "The user approves this exact audience, scope, and destination.",
+                    "blocking": not approved,
+                }
+            ],
+            next_steps=[
+                "Trusted backend resolves the source reference without returning the token.",
+                "Backend writes the token directly to the approved destination vault.",
+                "Source memory is cleared and only metadata is written to the audit trail.",
+                "Rotate or revoke the source token when this is a credential migration.",
+            ],
+            private_context={
+                "source_locator": request.source_ref.locator,
+                "destination_locator": request.destination_ref.locator,
+                "user_id": request.user_id,
+            },
         )
 
     def decide_action(self, action: str, *, explicit_user_approval: bool = False) -> ActionDecision:

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,6 +27,11 @@ import {
   toPublicConnection,
   toStoredConnection,
 } from "./connection-policy";
+import {
+  createPrivateTokenTransferPlan,
+  tokenTransferPlanRequestSchema,
+  toPublicTokenTransferPlan,
+} from "./token-transfer";
 
 const CORE_SLUGS = new Set(CORE_BOTS.map(b => b.slug));
 const GITHUB_SLUGS = new Set(GITHUB_BOTS.map(b => b.slug));
@@ -2759,6 +2764,17 @@ Any improvements or fixes (optional, 1-2 bullet points max)`;
     const parsed = signupHandoffRequestSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json(zodValidationError(parsed.error));
     res.status(201).json(createSignupHandoff(parsed.data));
+  });
+
+  app.post("/api/token-transfer-plans", async (req, res) => {
+    const killSwitch = await storage.getSetting("kill_switch");
+    if ((killSwitch?.value as { enabled?: boolean } | undefined)?.enabled) {
+      return res.status(423).json({ message: "Token transfers are locked by the kill switch" });
+    }
+    const parsed = tokenTransferPlanRequestSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json(zodValidationError(parsed.error));
+    const plan = createPrivateTokenTransferPlan(parsed.data);
+    res.status(201).json(toPublicTokenTransferPlan(plan));
   });
 
   // ===== KILL SWITCH =====

--- a/server/token-transfer.ts
+++ b/server/token-transfer.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from "crypto";
+import { z } from "zod";
+
+const SECRET_REFERENCE = /^[A-Za-z][A-Za-z0-9_.:/-]{2,127}$/;
+const TOKEN_LIKE = /(?:github_pat_|ghs_|(?:sk|rk)_(?:live|test)_|BEGIN .*PRIVATE KEY)/i;
+const SCOPE = /^[A-Za-z0-9._:/-]{1,80}$/;
+
+const referenceName = z.string().min(3).max(128).refine(
+  (value) => SECRET_REFERENCE.test(value) && !TOKEN_LIKE.test(value),
+  "Use a secret name or vault locator, never a token value",
+).refine(
+  (value) => value.length < 32 || !/^[A-Za-z0-9_-]+$/.test(value),
+  "High-entropy values are not valid secret references",
+);
+
+const httpsAudience = z.string().url().refine((value) => {
+  const parsed = new URL(value);
+  return parsed.protocol === "https:" && !parsed.username && !parsed.password && !parsed.search && !parsed.hash;
+}, "Use an official HTTPS audience without embedded credentials, query parameters, or fragments");
+
+const safeReason = z.string().trim().min(5).max(240).refine(
+  (value) => !TOKEN_LIKE.test(value) && !/[A-Za-z0-9_-]{32,}/.test(value),
+  "Transfer reason must not contain a token or credential value",
+);
+
+const sourceReferenceSchema = z.object({
+  provider: z.enum(["environment", "os_keychain", "managed_vault"]),
+  locator: referenceName,
+}).strict();
+
+const destinationReferenceSchema = z.object({
+  provider: z.enum(["os_keychain", "managed_vault"]),
+  locator: referenceName,
+}).strict();
+
+export const TOKEN_KINDS = [
+  "api_token",
+  "oauth_access_token",
+  "oauth_refresh_token",
+] as const;
+
+export const tokenTransferPlanRequestSchema = z.object({
+  connectorId: z.string().regex(/^[a-z][a-z0-9-]{2,63}$/),
+  tokenKind: z.enum(TOKEN_KINDS),
+  source: sourceReferenceSchema,
+  destination: destinationReferenceSchema,
+  sourceAudience: httpsAudience,
+  destinationAudience: httpsAudience,
+  scopes: z.array(z.string().regex(SCOPE)).max(40).default([]),
+  reason: safeReason,
+  ttlSeconds: z.number().int().min(30).max(300).default(120),
+  explicitUserApproval: z.boolean().default(false),
+}).strict().superRefine((value, context) => {
+  if (value.source.provider === "environment" && !/^[A-Z][A-Z0-9_]{2,127}$/.test(value.source.locator)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["source", "locator"],
+      message: "Environment references must use an uppercase variable name",
+    });
+  }
+  if (value.source.provider === value.destination.provider && value.source.locator === value.destination.locator) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["destination", "locator"],
+      message: "Source and destination references must be different",
+    });
+  }
+  if (new URL(value.sourceAudience).origin !== new URL(value.destinationAudience).origin) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["destinationAudience"],
+      message: "Tokens cannot move between app audiences; authorize the destination app separately",
+    });
+  }
+});
+
+export type TokenTransferPlanRequest = z.infer<typeof tokenTransferPlanRequestSchema>;
+
+export interface PrivateTokenTransferPlan {
+  transferId: string;
+  connectorId: string;
+  tokenKind: typeof TOKEN_KINDS[number];
+  status: "approval_required" | "backend_vault_execution_required";
+  audience: string;
+  scopes: string[];
+  reason: string;
+  source: TokenTransferPlanRequest["source"];
+  destination: TokenTransferPlanRequest["destination"];
+  createdAt: string;
+  expiresAt: string;
+  explicitUserApproval: boolean;
+}
+
+export interface PublicTokenTransferPlan {
+  schema: "dreamco.buddy_token_transfer.v1";
+  transferId: string;
+  connectorId: string;
+  tokenKind: typeof TOKEN_KINDS[number];
+  status: PrivateTokenTransferPlan["status"];
+  audience: string;
+  scopes: string[];
+  reason: string;
+  sourceProvider: TokenTransferPlanRequest["source"]["provider"];
+  destinationProvider: TokenTransferPlanRequest["destination"]["provider"];
+  sourceReferenceConfigured: true;
+  destinationReferenceConfigured: true;
+  createdAt: string;
+  expiresAt: string;
+  oneTime: true;
+  sameAudienceRequired: true;
+  rawTokenAccepted: false;
+}
+
+export function createPrivateTokenTransferPlan(
+  input: TokenTransferPlanRequest,
+  now = new Date(),
+): PrivateTokenTransferPlan {
+  const value = tokenTransferPlanRequestSchema.parse(input);
+  const scopes = [...new Set(value.scopes)];
+  return {
+    transferId: `transfer-${randomUUID()}`,
+    connectorId: value.connectorId,
+    tokenKind: value.tokenKind,
+    status: value.explicitUserApproval ? "backend_vault_execution_required" : "approval_required",
+    audience: new URL(value.sourceAudience).origin,
+    scopes,
+    reason: value.reason,
+    source: value.source,
+    destination: value.destination,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + value.ttlSeconds * 1000).toISOString(),
+    explicitUserApproval: value.explicitUserApproval,
+  };
+}
+
+export function toPublicTokenTransferPlan(plan: PrivateTokenTransferPlan): PublicTokenTransferPlan {
+  return {
+    schema: "dreamco.buddy_token_transfer.v1",
+    transferId: plan.transferId,
+    connectorId: plan.connectorId,
+    tokenKind: plan.tokenKind,
+    status: plan.status,
+    audience: plan.audience,
+    scopes: plan.scopes,
+    reason: plan.reason,
+    sourceProvider: plan.source.provider,
+    destinationProvider: plan.destination.provider,
+    sourceReferenceConfigured: true,
+    destinationReferenceConfigured: true,
+    createdAt: plan.createdAt,
+    expiresAt: plan.expiresAt,
+    oneTime: true,
+    sameAudienceRequired: true,
+    rawTokenAccepted: false,
+  };
+}
+
+export interface SecretVaultAdapter {
+  readonly provider: TokenTransferPlanRequest["source"]["provider"];
+  // Return a dedicated mutable buffer; the broker zeroes it after the write attempt.
+  read(locator: string): Promise<Uint8Array>;
+  // Implementations must copy the value into an atomic vault write before resolving.
+  write(
+    locator: string,
+    value: Uint8Array,
+    metadata: Readonly<{ connectorId: string; tokenKind: string; audience: string; scopes: string[] }>,
+  ): Promise<void>;
+}
+
+export interface TransferReplayGuard {
+  // Production implementations must claim atomically in a shared durable store.
+  claim(transferId: string, expiresAt: string): Promise<boolean>;
+}
+
+export interface TokenTransferReceipt {
+  schema: "dreamco.buddy_token_transfer_receipt.v1";
+  transferId: string;
+  connectorId: string;
+  status: "transferred";
+  audience: string;
+  tokenKind: string;
+  sourceProvider: string;
+  destinationProvider: string;
+  transferredAt: string;
+  rawTokenReturned: false;
+}
+
+export async function executeTokenTransfer(
+  plan: PrivateTokenTransferPlan,
+  sourceVault: SecretVaultAdapter,
+  destinationVault: SecretVaultAdapter,
+  replayGuard: TransferReplayGuard,
+  onAudit?: (receipt: TokenTransferReceipt) => Promise<void> | void,
+  now = new Date(),
+): Promise<TokenTransferReceipt> {
+  if (!plan.explicitUserApproval || plan.status !== "backend_vault_execution_required") {
+    throw new Error("Explicit user approval is required before token transfer");
+  }
+  if (now.getTime() >= Date.parse(plan.expiresAt)) {
+    throw new Error("Token transfer plan has expired");
+  }
+  if (sourceVault.provider !== plan.source.provider || destinationVault.provider !== plan.destination.provider) {
+    throw new Error("Vault adapter does not match the approved transfer plan");
+  }
+  if (!(await replayGuard.claim(plan.transferId, plan.expiresAt))) {
+    throw new Error("Token transfer plan has already been used");
+  }
+
+  let token: Uint8Array | undefined;
+  try {
+    token = await sourceVault.read(plan.source.locator);
+    if (token.byteLength < 1 || token.byteLength > 65_536) {
+      throw new Error("Source vault returned an invalid token payload");
+    }
+    await destinationVault.write(plan.destination.locator, token, {
+      connectorId: plan.connectorId,
+      tokenKind: plan.tokenKind,
+      audience: plan.audience,
+      scopes: [...plan.scopes],
+    });
+    const receipt: TokenTransferReceipt = {
+      schema: "dreamco.buddy_token_transfer_receipt.v1",
+      transferId: plan.transferId,
+      connectorId: plan.connectorId,
+      status: "transferred",
+      audience: plan.audience,
+      tokenKind: plan.tokenKind,
+      sourceProvider: plan.source.provider,
+      destinationProvider: plan.destination.provider,
+      transferredAt: now.toISOString(),
+      rawTokenReturned: false,
+    };
+    await onAudit?.(receipt);
+    return receipt;
+  } finally {
+    token?.fill(0);
+  }
+}

--- a/tests/connection-policy.test.ts
+++ b/tests/connection-policy.test.ts
@@ -7,6 +7,14 @@ import {
   toPublicConnection,
   toStoredConnection,
 } from "../server/connection-policy";
+import {
+  createPrivateTokenTransferPlan,
+  executeTokenTransfer,
+  tokenTransferPlanRequestSchema,
+  toPublicTokenTransferPlan,
+  type SecretVaultAdapter,
+  type TransferReplayGuard,
+} from "../server/token-transfer";
 import type { PlatformConnection } from "../shared/schema";
 
 test("connection plans store references rather than credential values", () => {
@@ -95,4 +103,101 @@ test("signup handoffs cannot submit protected steps", () => {
   assert.ok(handoff.userPresenceGates.includes("terms_and_privacy"));
   assert.ok(handoff.userPresenceGates.includes("captcha"));
   assert.ok(handoff.userPresenceGates.includes("payment"));
+});
+
+test("token handoff accepts references only and blocks cross-app audiences", () => {
+  const rawToken = tokenTransferPlanRequestSchema.safeParse({
+    connectorId: "client-app",
+    tokenKind: "api_token",
+    source: { provider: "environment", locator: "CLIENT_API_TOKEN" },
+    destination: { provider: "managed_vault", locator: "clients/client-app/api-token" },
+    sourceAudience: "https://app.example.com",
+    destinationAudience: "https://app.example.com",
+    reason: "Move the approved token into managed storage.",
+    explicitUserApproval: true,
+    token: "sk_live_1234567890123456",
+  });
+  assert.equal(rawToken.success, false);
+
+  const crossApp = tokenTransferPlanRequestSchema.safeParse({
+    connectorId: "client-app",
+    tokenKind: "oauth_access_token",
+    source: { provider: "environment", locator: "CLIENT_ACCESS_TOKEN" },
+    destination: { provider: "managed_vault", locator: "clients/client-app/access-token" },
+    sourceAudience: "https://app.example.com",
+    destinationAudience: "https://other.example.com",
+    reason: "Move the approved token into managed storage.",
+    explicitUserApproval: true,
+  });
+  assert.equal(crossApp.success, false);
+
+  const tokenInReason = tokenTransferPlanRequestSchema.safeParse({
+    connectorId: "client-app",
+    tokenKind: "api_token",
+    source: { provider: "environment", locator: "CLIENT_API_TOKEN" },
+    destination: { provider: "managed_vault", locator: "clients/client-app/api-token" },
+    sourceAudience: "https://app.example.com",
+    destinationAudience: "https://app.example.com",
+    reason: "Move sk_live_1234567890123456 into storage.",
+    explicitUserApproval: true,
+  });
+  assert.equal(tokenInReason.success, false);
+});
+
+test("token handoff is one-time, clears source memory, and returns metadata only", async () => {
+  const input = tokenTransferPlanRequestSchema.parse({
+    connectorId: "client-app",
+    tokenKind: "oauth_access_token",
+    source: { provider: "environment", locator: "CLIENT_ACCESS_TOKEN" },
+    destination: { provider: "managed_vault", locator: "clients/client-app/access-token" },
+    sourceAudience: "https://app.example.com/oauth",
+    destinationAudience: "https://app.example.com/api",
+    scopes: ["profile.read"],
+    reason: "Move the approved token into managed storage.",
+    ttlSeconds: 60,
+    explicitUserApproval: true,
+  });
+  const now = new Date("2026-07-21T12:00:00Z");
+  const plan = createPrivateTokenTransferPlan(input, now);
+  const publicPlan = toPublicTokenTransferPlan(plan);
+  assert.equal(JSON.stringify(publicPlan).includes("CLIENT_ACCESS_TOKEN"), false);
+  assert.equal(JSON.stringify(publicPlan).includes("clients/client-app/access-token"), false);
+
+  const sourceBytes = new TextEncoder().encode("private-test-token");
+  let destinationCopy = new Uint8Array();
+  const sourceVault: SecretVaultAdapter = {
+    provider: "environment",
+    async read() { return sourceBytes; },
+    async write() { throw new Error("Source vault is read-only"); },
+  };
+  const destinationVault: SecretVaultAdapter = {
+    provider: "managed_vault",
+    async read() { throw new Error("Destination read is unused"); },
+    async write(_locator, value) { destinationCopy = Uint8Array.from(value); },
+  };
+  const claimed = new Set<string>();
+  const replayGuard: TransferReplayGuard = {
+    async claim(id) {
+      if (claimed.has(id)) return false;
+      claimed.add(id);
+      return true;
+    },
+  };
+
+  const receipt = await executeTokenTransfer(
+    plan,
+    sourceVault,
+    destinationVault,
+    replayGuard,
+    undefined,
+    new Date("2026-07-21T12:00:10Z"),
+  );
+  assert.equal(new TextDecoder().decode(destinationCopy), "private-test-token");
+  assert.ok(sourceBytes.every((value) => value === 0));
+  assert.equal(receipt.rawTokenReturned, false);
+  assert.equal(JSON.stringify(receipt).includes("private-test-token"), false);
+  await assert.rejects(
+    executeTokenTransfer(plan, sourceVault, destinationVault, replayGuard, undefined, new Date("2026-07-21T12:00:20Z")),
+    /already been used/,
+  );
 });

--- a/tests/test_buddy_connection_broker.py
+++ b/tests/test_buddy_connection_broker.py
@@ -19,6 +19,8 @@ from dreamco_platform.connections import (
     ConnectorSpec,
     SecretReference,
     SignupRequest,
+    TokenKind,
+    TokenTransferRequest,
 )
 
 
@@ -137,6 +139,48 @@ class BuddyConnectionBrokerTests(unittest.TestCase):
         self.assertEqual(money.status, "approval_required")
         approved = self.broker.decide_action("transfer_funds", explicit_user_approval=True)
         self.assertTrue(approved.allowed)
+
+    def test_token_transfer_is_reference_only_same_audience_and_short_lived(self):
+        plan = self.broker.create_token_transfer_plan(
+            TokenTransferRequest(
+                user_id="owner-1",
+                connector_id="client-app",
+                token_kind=TokenKind.OAUTH_ACCESS_TOKEN,
+                source_ref=SecretReference("environment", "CLIENT_ACCESS_TOKEN"),
+                destination_ref=SecretReference("managed_vault", "clients/client-app/access-token"),
+                source_audience="https://app.example.com/oauth",
+                destination_audience="https://app.example.com/api",
+                reason="Move the approved connection into managed storage.",
+                scopes=("profile.read",),
+                ttl_seconds=60,
+                explicit_user_approval=True,
+            )
+        )
+        public = plan.to_public_dict()
+        self.assertEqual(public["status"], "backend_vault_execution_required")
+        self.assertTrue(public["one_time"])
+        self.assertFalse(public["raw_token_accepted"])
+        self.assertNotIn("source_locator", str(public))
+        self.assertNotIn("CLIENT_ACCESS_TOKEN", str(public))
+
+    def test_token_transfer_blocks_cross_app_and_unwritable_destinations(self):
+        base = dict(
+            user_id="owner-1",
+            connector_id="client-app",
+            token_kind=TokenKind.API_TOKEN,
+            source_ref=SecretReference("environment", "CLIENT_API_TOKEN"),
+            destination_ref=SecretReference("managed_vault", "clients/client-app/api-token"),
+            source_audience="https://app.example.com",
+            destination_audience="https://other.example.com",
+            reason="Move an approved API token.",
+        )
+        with self.assertRaisesRegex(ConnectionBrokerError, "between app audiences"):
+            self.broker.create_token_transfer_plan(TokenTransferRequest(**base))
+
+        base["destination_audience"] = "https://app.example.com"
+        base["destination_ref"] = SecretReference("environment", "DESTINATION_API_TOKEN")
+        with self.assertRaisesRegex(ConnectionBrokerError, "writable keychain"):
+            self.broker.create_token_transfer_plan(TokenTransferRequest(**base))
 
     def test_registry_generation_stays_in_sync(self):
         result = subprocess.run(

--- a/tools/generate_buddy_connection_catalog.py
+++ b/tools/generate_buddy_connection_catalog.py
@@ -32,6 +32,7 @@ def build_public_catalog(payload: dict[str, Any]) -> dict[str, Any]:
     methods = payload.get("auth_methods", [])
     gates = payload.get("user_presence_gates", [])
     contracts = payload.get("connector_contracts", [])
+    transfer = payload.get("token_transfer", {})
     expected_methods = {method.value for method in AuthMethod}
     method_ids = [str(item.get("id", "")) for item in methods]
     if set(method_ids) != expected_methods or len(method_ids) != len(set(method_ids)):
@@ -46,6 +47,16 @@ def build_public_catalog(payload: dict[str, Any]) -> dict[str, Any]:
     summary = payload.get("summary", {})
     if summary.get("raw_credentials_accepted") is not False:
         raise ValueError("Buddy connector registry must reject raw credentials.")
+    if transfer.get("mode") != "reference_to_reference":
+        raise ValueError("Token transfer must use reference-to-reference mode.")
+    if transfer.get("same_audience_required") is not True:
+        raise ValueError("Token transfer must remain bound to one app audience.")
+    if transfer.get("explicit_user_approval_required") is not True:
+        raise ValueError("Token transfer must require explicit user approval.")
+    if transfer.get("one_time_execution") is not True:
+        raise ValueError("Token transfer must be single use.")
+    if transfer.get("raw_tokens_accepted_in_public_clients") is not False:
+        raise ValueError("Public clients must reject raw token values.")
 
     return {
         "schema": "dreamco.public_buddy_connection_catalog.v1",
@@ -58,6 +69,7 @@ def build_public_catalog(payload: dict[str, Any]) -> dict[str, Any]:
         "auth_methods": methods,
         "user_presence_gates": gates,
         "connector_contracts": contracts,
+        "token_transfer": transfer,
         "public_contract": {
             "mode": "connection_planner",
             "live_authentication": False,
@@ -66,6 +78,7 @@ def build_public_catalog(payload: dict[str, Any]) -> dict[str, Any]:
             "stored_browser_data": ["plan status", "app label", "official host", "timestamp"],
             "backend_required_for": [
                 "token exchange",
+                "token transfer execution",
                 "secret resolution",
                 "live API calls",
                 "connection revocation",

--- a/website/connections.html
+++ b/website/connections.html
@@ -31,6 +31,7 @@
   <nav class="connection-tabs" aria-label="Connection views">
     <button class="settings-tab active" type="button" data-panel="catalog-panel">Catalog</button>
     <button class="settings-tab" type="button" data-panel="connect-panel">Connect app</button>
+    <button class="settings-tab" type="button" data-panel="transfer-panel">Token handoff</button>
     <button class="settings-tab" type="button" data-panel="signup-panel">Sign-up queue</button>
     <button class="settings-tab" type="button" data-panel="audit-panel">Audit</button>
   </nav>
@@ -95,6 +96,91 @@
         <div class="empty-connection-state">
           <strong>No active plan</strong>
           <span>Connection plans appear here before backend execution.</span>
+        </div>
+      </section>
+    </div>
+  </section>
+
+  <section id="transfer-panel" class="connection-panel" hidden>
+    <div class="connections-workbench">
+      <form id="transfer-form" class="connection-surface connection-form">
+        <div class="connection-section-heading">
+          <div><span class="status-dot status-dot-warn"></span><strong>Vault-to-vault handoff</strong></div>
+          <span class="badge badge-green">References only</span>
+        </div>
+
+        <label for="transfer-connector">Connector id</label>
+        <input id="transfer-connector" name="connector" type="text" pattern="[a-z][a-z0-9-]{2,63}" placeholder="client-app" required />
+
+        <label for="transfer-kind">Token class</label>
+        <select id="transfer-kind" name="kind" required>
+          <option value="api_token">API token</option>
+          <option value="oauth_access_token">OAuth access token</option>
+          <option value="oauth_refresh_token">OAuth refresh token</option>
+        </select>
+
+        <div class="connection-inline-fields">
+          <div>
+            <label for="transfer-source-provider">Source storage</label>
+            <select id="transfer-source-provider" name="sourceProvider">
+              <option value="environment">Environment variable</option>
+              <option value="os_keychain">OS keychain</option>
+              <option value="managed_vault">Managed vault</option>
+            </select>
+          </div>
+          <div>
+            <label for="transfer-destination-provider">Destination storage</label>
+            <select id="transfer-destination-provider" name="destinationProvider">
+              <option value="managed_vault">Managed vault</option>
+              <option value="os_keychain">OS keychain</option>
+            </select>
+          </div>
+        </div>
+
+        <label for="transfer-source-reference">Source reference name</label>
+        <input id="transfer-source-reference" name="sourceReference" type="text" placeholder="CLIENT_APP_TOKEN" autocomplete="off" spellcheck="false" required />
+
+        <label for="transfer-destination-reference">Destination reference name</label>
+        <input id="transfer-destination-reference" name="destinationReference" type="text" placeholder="clients/client-app/token" autocomplete="off" spellcheck="false" required />
+        <small>Enter vault locators only. Tokens, cookies, passwords, and recovery codes are rejected.</small>
+
+        <label for="transfer-source-audience">Current app audience</label>
+        <input id="transfer-source-audience" name="sourceAudience" type="url" placeholder="https://app.example.com" required />
+
+        <label for="transfer-destination-audience">Destination app audience</label>
+        <input id="transfer-destination-audience" name="destinationAudience" type="url" placeholder="https://app.example.com" required />
+
+        <label for="transfer-scopes">Approved scopes</label>
+        <input id="transfer-scopes" name="scopes" type="text" placeholder="profile.read, projects.read" />
+
+        <div class="connection-inline-fields">
+          <div>
+            <label for="transfer-ttl">Plan lifetime</label>
+            <select id="transfer-ttl" name="ttl">
+              <option value="60">1 minute</option>
+              <option value="120" selected>2 minutes</option>
+              <option value="300">5 minutes</option>
+            </select>
+          </div>
+          <div>
+            <label for="transfer-reason">Reason</label>
+            <input id="transfer-reason" name="reason" type="text" minlength="5" maxlength="240" placeholder="Move approved token to managed storage" required />
+          </div>
+        </div>
+
+        <label class="connection-approval" for="transfer-approval">
+          <input id="transfer-approval" name="approval" type="checkbox" required />
+          <span>I approve this exact same-app token handoff.</span>
+        </label>
+
+        <button class="btn btn-primary" type="submit">Prepare secure handoff</button>
+        <p id="transfer-error" class="connection-error" role="alert" hidden></p>
+      </form>
+
+      <section id="transfer-result" class="connection-surface connection-result" aria-live="polite">
+        <div class="empty-connection-state">
+          <strong>No token handoff</strong>
+          <span>Buddy never asks for or displays the token value.</span>
         </div>
       </section>
     </div>

--- a/website/connections.js
+++ b/website/connections.js
@@ -51,6 +51,16 @@
     target.hidden = !message;
   }
 
+  function validatedSecretReference(raw, provider) {
+    const value = String(raw || '').trim();
+    const highEntropyValue = value.length >= 32 && /^[A-Za-z0-9_-]+$/.test(value);
+    const invalidEnvironmentName = provider === 'environment' && !/^[A-Z][A-Z0-9_]{2,127}$/.test(value);
+    if (!SECRET_NAME.test(value) || TOKEN_LIKE.test(value) || highEntropyValue || invalidEnvironmentName) {
+      throw new Error('Enter a secret reference name, not a key or token value.');
+    }
+    return value;
+  }
+
   function statusLabel(method) {
     if (method.status === 'adapter_ready') return 'Adapter ready';
     if (method.status === 'user_handoff') return 'User handoff';
@@ -208,17 +218,110 @@
       }
 
       const secretProvider = String(form.get('secretProvider') || '');
-      const secretReference = String(form.get('secretReference') || '').trim();
-      const highEntropyValue = secretReference.length >= 32 && /^[A-Za-z0-9_-]+$/.test(secretReference);
-      const invalidEnvironmentName = secretProvider === 'environment' && !/^[A-Z][A-Z0-9_]{2,127}$/.test(secretReference);
-      if (method.secret_reference_required && (!SECRET_NAME.test(secretReference) || TOKEN_LIKE.test(secretReference) || highEntropyValue || invalidEnvironmentName)) {
-        throw new Error('Enter a secret reference name, not a key or token value.');
-      }
+      const secretReference = method.secret_reference_required
+        ? validatedSecretReference(String(form.get('secretReference') || ''), secretProvider)
+        : '';
 
       renderConnectionPlan({ app, url, method, scopes, secretProvider, secretReference });
       addAudit({ type: 'connection_plan', app, host: url.hostname, method: method.id, status: 'user_action_required' });
     } catch (error) {
       setError('connection-error', error.message || 'Unable to prepare the connection plan.');
+    }
+  }
+
+  function renderTransferPlan({ connector, kind, sourceProvider, destinationProvider, audience, scopes, reason, ttl }) {
+    const target = byId('transfer-result');
+    target.replaceChildren();
+    appendPlanHeading(target, connector, 'Backend vault required', 'badge badge-amber');
+
+    const summary = element('dl', 'connection-plan-summary');
+    [
+      ['Token class', kind.replaceAll('_', ' ')],
+      ['App audience', audience.origin],
+      ['Scopes', scopes.length ? scopes.join(', ') : 'Provider minimum'],
+      ['Source', `${sourceProvider} reference configured`],
+      ['Destination', `${destinationProvider} reference configured`],
+      ['Expires', `${ttl} seconds after creation`],
+      ['Approval', 'Recorded for this handoff only'],
+      ['Reason', reason],
+    ].forEach(([label, value]) => {
+      summary.append(element('dt', '', label), element('dd', '', value));
+    });
+    target.append(summary);
+    appendPlanList(target, 'Secure transfer path', [
+      'Trusted backend resolves the source reference without returning the token.',
+      'Backend writes directly to the approved destination for the same app audience.',
+      'The one-time plan is consumed and source memory is cleared.',
+      'Only transfer metadata is retained; rotate the source token after a migration.',
+    ]);
+
+    const footer = element('div', 'connection-plan-footer');
+    footer.append(element('span', 'status-dot status-dot-warn'), element('span', '', 'Static preview: a configured backend vault performs the transfer.'));
+    target.append(footer);
+  }
+
+  function handleTransfer(event) {
+    event.preventDefault();
+    setError('transfer-error', '');
+    if (state.locked) {
+      setError('transfer-error', 'Unlock the planner before preparing a token handoff.');
+      return;
+    }
+    try {
+      const form = new FormData(event.currentTarget);
+      const connector = String(form.get('connector') || '').trim();
+      if (!/^[a-z][a-z0-9-]{2,63}$/.test(connector)) {
+        throw new Error('Connector id must be a lowercase app slug.');
+      }
+      const kind = String(form.get('kind') || '');
+      const allowedKinds = state.catalog.token_transfer.allowed_token_kinds;
+      if (!allowedKinds.includes(kind)) throw new Error('Choose an approved transferable token class.');
+
+      const sourceProvider = String(form.get('sourceProvider') || '');
+      const destinationProvider = String(form.get('destinationProvider') || '');
+      const sourceReference = validatedSecretReference(form.get('sourceReference'), sourceProvider);
+      const destinationReference = validatedSecretReference(form.get('destinationReference'), destinationProvider);
+      if (sourceProvider === destinationProvider && sourceReference === destinationReference) {
+        throw new Error('Source and destination references must be different.');
+      }
+      if (!state.catalog.token_transfer.writable_destinations.includes(destinationProvider)) {
+        throw new Error('Destination must be a writable keychain or managed vault.');
+      }
+
+      const sourceAudience = officialUrl(String(form.get('sourceAudience') || ''));
+      const destinationAudience = officialUrl(String(form.get('destinationAudience') || ''));
+      if (sourceAudience.origin !== destinationAudience.origin) {
+        throw new Error('Tokens cannot move between apps. Authorize the destination app separately.');
+      }
+      const scopes = String(form.get('scopes') || '')
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+      if (scopes.some((scope) => !/^[A-Za-z0-9._:/-]{1,80}$/.test(scope))) {
+        throw new Error('Scopes may use letters, numbers, dots, slashes, colons, dashes, and underscores.');
+      }
+      const reason = String(form.get('reason') || '').trim();
+      const ttl = Number(form.get('ttl'));
+      if (reason.length < 5) throw new Error('A clear transfer reason is required.');
+      if (TOKEN_LIKE.test(reason) || /[A-Za-z0-9_-]{32,}/.test(reason)) {
+        throw new Error('Transfer reason must not contain a key or token value.');
+      }
+      if (sourceAudience.search || sourceAudience.hash || destinationAudience.search || destinationAudience.hash) {
+        throw new Error('App audiences must not contain query parameters or fragments.');
+      }
+      if (![60, 120, 300].includes(ttl)) throw new Error('Choose an approved short plan lifetime.');
+      if (form.get('approval') !== 'on') throw new Error('Explicit approval is required for this handoff.');
+
+      renderTransferPlan({ connector, kind, sourceProvider, destinationProvider, audience: sourceAudience, scopes, reason, ttl });
+      addAudit({
+        type: 'token_handoff',
+        app: connector,
+        host: sourceAudience.hostname,
+        method: kind,
+        status: 'backend_vault_execution_required',
+      });
+    } catch (error) {
+      setError('transfer-error', error.message || 'Unable to prepare the token handoff.');
     }
   }
 
@@ -317,6 +420,7 @@
     byId('planner-lock').addEventListener('click', toggleLock);
     byId('connection-method').addEventListener('change', updateSecretFields);
     byId('connection-form').addEventListener('submit', handleConnection);
+    byId('transfer-form').addEventListener('submit', handleTransfer);
     byId('signup-form').addEventListener('submit', handleSignup);
     byId('clear-connection-audit').addEventListener('click', () => {
       state.audit = [];

--- a/website/data/buddy-connection-catalog.json
+++ b/website/data/buddy-connection-catalog.json
@@ -100,6 +100,7 @@
   "public_contract": {
     "backend_required_for": [
       "token exchange",
+      "token transfer execution",
       "secret resolution",
       "live API calls",
       "connection revocation"
@@ -124,6 +125,30 @@
     "secret_storage": "reference_only",
     "signup_mode": "assisted_handoff",
     "user_presence_gate_count": 7
+  },
+  "token_transfer": {
+    "allowed_token_kinds": [
+      "api_token",
+      "oauth_access_token",
+      "oauth_refresh_token"
+    ],
+    "blocked_token_kinds": [
+      "browser_session_cookie",
+      "identity_token",
+      "payment_token",
+      "recovery_code"
+    ],
+    "explicit_user_approval_required": true,
+    "max_plan_ttl_seconds": 300,
+    "mode": "reference_to_reference",
+    "one_time_execution": true,
+    "raw_tokens_accepted_in_public_clients": false,
+    "same_audience_required": true,
+    "status": "backend_vault_required",
+    "writable_destinations": [
+      "os_keychain",
+      "managed_vault"
+    ]
   },
   "user_presence_gates": [
     {

--- a/website/styles.css
+++ b/website/styles.css
@@ -1058,6 +1058,32 @@ textarea.studio-input { min-height: 104px; resize: vertical; line-height: 1.55; 
 }
 .connection-form small { color: var(--text3); font-size: .7rem; line-height: 1.45; }
 .connection-form .btn { margin-top: 10px; }
+.connection-inline-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+.connection-inline-fields > div { min-width: 0; }
+.connection-inline-fields label { display: block; margin-bottom: 8px; }
+.connection-approval {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  background: var(--card2);
+  cursor: pointer;
+}
+.connection-form .connection-approval input[type="checkbox"] {
+  width: 18px;
+  min-height: 18px;
+  height: 18px;
+  margin: 1px 0 0;
+  accent-color: var(--primary);
+  flex: 0 0 18px;
+}
+.connection-approval span { color: var(--text2); font-size: .76rem; line-height: 1.45; }
 .connection-error {
   color: #fca5a5;
   background: rgba(239,68,68,.08);
@@ -1258,6 +1284,7 @@ footer {
   .connection-metrics > div:nth-last-child(-n+2) { border-bottom: 0; }
   .auth-method-grid,
   .connections-two-column { grid-template-columns: 1fr; }
+  .connection-inline-fields { grid-template-columns: 1fr; }
   .connection-surface { padding: 16px; }
   .connection-plan-summary { grid-template-columns: 96px minmax(0, 1fr); }
   .audit-row { align-items: flex-start; flex-direction: column; padding: 12px 0; }


### PR DESCRIPTION
## What changed
- add a governed, short-lived token-transfer plan for API and OAuth tokens
- require same-app audience binding, explicit approval, one-time replay protection, and writable vault destinations
- add a backend vault execution interface that clears token bytes and returns metadata-only receipts
- add the Token handoff workbench to the public Connections page
- publish the policy in the generated connector catalog

## Safety
Public clients accept secret references only. Browser cookies, identity tokens, payment tokens, recovery codes, cross-app transfers, credential-bearing URLs, and raw token fields are rejected. Actual transfer execution remains backend-only and requires configured vault adapters plus a durable replay guard.

## Validation
- 8 Python connection broker tests
- 6 TypeScript policy and execution tests
- public site preflight: 29 HTML pages, 43 public files, no warnings
- connector catalog drift check
- JavaScript syntax check
- bundled server route build
- browser validation of a same-audience, reference-only handoff