### PR TITLE
Document locked DreamCo Lite proof-first roadmap

### DIFF
--- a/docs/dreamco-lite/DREAMCO_LITE_MVP.md
+++ b/docs/dreamco-lite/DREAMCO_LITE_MVP.md
@@ -1,0 +1,140 @@
+# DreamCo Lite — Locked MVP
+
+## Decision
+
+DreamCo Lite is the required first shipping target before any repo-wide Lite System, recursive builder network, full multi-agent platform, or Buddy mega-orchestrator expansion.
+
+The MVP is intentionally small:
+
+- **2 bots**
+- **1 UI**
+- **5-day build cycle**
+- **1 proven workflow:** leads → outreach messages → usable output
+
+The goal is not to prove that DreamCo can contain hundreds of bots. The goal is to prove that one small DreamCo product can create useful, actionable results for a real user.
+
+## Core Bots
+
+### Money Bot v1
+
+Purpose: produce immediate user value.
+
+Inputs:
+
+- target niche
+- target location
+
+Outputs:
+
+- relevant leads
+- business/contact information when available
+- personalized outreach messages
+- copy-ready or export-ready results
+
+Initial workflow:
+
+1. User enters niche and location.
+2. User selects **Find Leads**.
+3. Money Bot returns a small lead set.
+4. User selects **Generate Messages**.
+5. Money Bot generates outreach for the selected leads.
+6. User can select **Run Automation** to perform the proven sequence in one action.
+
+### Debug Bot v1
+
+Purpose: support the MVP during early development and testing.
+
+Inputs:
+
+- error message
+- log output
+- failed task context
+
+Outputs:
+
+- plain-English explanation
+- likely root cause
+- suggested next fix
+
+Debug Bot v1 is intentionally simple. It is not a self-repairing autonomous platform, a repo-wide repair service, or a recursive builder.
+
+## Single-Page UI
+
+The Lite UI contains only what is necessary to prove the workflow.
+
+Required controls:
+
+- niche input
+- location input
+- **Find Leads** button
+- **Generate Messages** button
+- **Run Automation** button
+- output panel for leads, generated messages, and errors
+
+Not part of the locked MVP:
+
+- drag-and-drop workflow builder
+- recursive bot creation
+- autonomous builder fleets
+- multi-agent debate systems
+- Kubernetes or distributed orchestration
+- global repo scanning
+- automatic Lite Systems attached to every bot
+- advanced client dashboards
+- predictive auto-scaling
+- full Buddy orchestration
+
+## Five-Day Build Cycle
+
+### Day 1 — UI skeleton
+
+Acceptance target:
+
+- single page loads
+- niche and location can be entered
+- all three action buttons render
+- output panel can display mock results
+
+### Day 2 — Lead engine
+
+Acceptance target:
+
+- **Find Leads** returns a usable lead list from one source
+- if an external lead source blocks progress, the UI/backend contract may be validated with mock data first rather than delaying the entire MVP
+
+### Day 3 — Message engine
+
+Acceptance target:
+
+- **Generate Messages** converts returned leads into usable outreach copy
+- messages use the lead/business/niche context and are not generic placeholders
+
+### Day 4 — Debug Bot
+
+Acceptance target:
+
+- failed MVP operations can send error/log context to Debug Bot
+- Debug Bot returns a readable explanation and a suggested corrective action
+
+### Day 5 — Connect, test, deploy
+
+Acceptance target:
+
+- **Run Automation** executes the validated leads → messages sequence
+- outputs are visible in the UI
+- the deployed MVP can be tested by a real person outside the development path
+
+## MVP Exit Criteria
+
+DreamCo Lite is considered validated only when a real user can:
+
+1. enter a niche and location;
+2. obtain real or operationally usable leads;
+3. generate outreach worth sending;
+4. act on the output without needing to understand DreamCo internals.
+
+Shipping comes before polishing. A working, limited MVP is preferred over a sophisticated unfinished platform.
+
+## Scope Lock Rule
+
+Until the MVP exit criteria are met, do not expand the build because a feature is interesting. New work must directly improve the leads → messages → action workflow or remove a blocker preventing that workflow from working.

--- a/docs/dreamco-lite/PROOF_MODE.md
+++ b/docs/dreamco-lite/PROOF_MODE.md
@@ -1,0 +1,103 @@
+# DreamCo Lite — Proof Mode
+
+## Purpose
+
+Proof Mode exists to prevent DreamCo from upgrading Money Bot before Money Bot v1 has demonstrated useful output in the real world.
+
+Do not build Money Bot v2 simply because telemetry, embedded debugging, adaptive prompts, or self-improvement sound useful. First identify the actual problems exposed by v1.
+
+## Required Test Scenarios
+
+Run at least three materially different lead-generation scenarios. Example set:
+
+1. Roofing companies in Wisconsin
+2. Local gyms in Chicago
+3. Real estate agents in Texas
+
+Equivalent live scenarios may be substituted when they better match a real sales opportunity.
+
+## Lead Quality Review
+
+For each run, score:
+
+- Are the leads real?
+- Are they relevant to the requested niche/location?
+- Is the business/contact data usable?
+- Would a salesperson actually contact these leads?
+
+Recommended score: 1–10.
+
+## Message Quality Review
+
+For each run, score:
+
+- Does the message sound natural?
+- Does it use the lead's actual context?
+- Is the value proposition clear?
+- Would the message be sent with little or no editing?
+- Does it avoid unsupported claims or fabricated personalization?
+
+Recommended score: 1–10.
+
+## Action Test
+
+The most important test is whether the output can be acted on.
+
+For at least one lead in each scenario:
+
+1. review the contact information;
+2. review the generated outreach;
+3. edit only if necessary;
+4. determine whether the message is ready to send or use in a real sales interaction.
+
+Where appropriate and authorized, use the output in an actual outreach attempt and record the result.
+
+## Manual Scorecard
+
+No complex telemetry platform is required for Proof Mode. A simple record is enough.
+
+```text
+Scenario:
+Niche:
+Location:
+Lead source:
+
+Lead quality: __/10
+Message quality: __/10
+Actionability: __/10
+
+Problems observed:
+- 
+- 
+
+What worked:
+- 
+- 
+
+Would I use this again? yes/no
+Would I pay for this output? yes/no/unclear
+```
+
+## Proof Gate
+
+Money Bot v1 passes Proof Mode when:
+
+- multiple runs return operationally useful leads;
+- outreach is usable with limited editing;
+- at least one real user can complete the workflow without developer intervention;
+- observed failures are specific enough to define the v2 backlog.
+
+If those conditions are not met, improve v1 instead of expanding the architecture.
+
+## What Proof Mode Produces
+
+The result of Proof Mode is not merely a pass/fail decision. It becomes the evidence-based Money Bot v2 specification.
+
+Examples:
+
+- If lead quality is weak, improve sourcing/ranking before adding telemetry.
+- If messages are generic, improve prompt/context construction before adding autonomous builders.
+- If lead sources fail frequently, add targeted retry/fallback logic based on those real failures.
+- If users struggle with the UI, fix the interaction before building a visual workflow builder.
+
+**v1 discovers the problems. v2 solves the problems that actually occurred.**

--- a/docs/dreamco-lite/UPGRADE_LADDER.md
+++ b/docs/dreamco-lite/UPGRADE_LADDER.md
@@ -1,0 +1,152 @@
+# DreamCo Upgrade Ladder — Lite to Super
+
+## Principle
+
+DreamCo expands only after the previous level proves value. Architecture is earned by usage, not added in advance.
+
+## Level 1 — DreamCo Lite
+
+Current target:
+
+- Money Bot v1
+- Debug Bot v1
+- one simple UI
+- leads → outreach → usable output
+
+Upgrade only after Proof Mode passes.
+
+## Level 2 — First Lite System
+
+The first proven bot becomes the first Lite System candidate.
+
+For Money Bot, possible upgrades include:
+
+- lightweight telemetry for runs, successes, failures, and lead/message quality signals;
+- local error handling and targeted fallback behavior for failures actually observed in Proof Mode;
+- minimal prompt/workflow adaptation based on niche and validated user needs.
+
+Do not add all possible features automatically. Add only improvements supported by evidence.
+
+## Level 3 — Reusable Lite System Template
+
+After one bot has been upgraded successfully, extract the useful parts into a reusable template.
+
+Candidate template modules:
+
+- telemetry
+- error/debug adapter
+- task-specific configuration
+- small workflow extension points
+
+The template should remain optional and composable rather than forcing every bot into the same architecture.
+
+## Level 4 — Selective Expansion
+
+Apply the Lite System template only to bots that demonstrate meaningful usage, revenue potential, operational importance, or recurring failure patterns.
+
+Avoid repo-wide attachment merely because a bot exists.
+
+## Level 5 — Workflow Intelligence
+
+When users consistently need multi-step execution, add explicit workflow chaining.
+
+Example progression:
+
+1. leads → messages → export
+2. leads → messages → approved send action
+3. domain-specific workflow templates
+
+Human approval checkpoints remain available for consequential actions.
+
+## Level 6 — Visual Builder
+
+Build drag-and-drop workflow composition when real users need customization beyond prebuilt workflows.
+
+The visual builder should expose proven capabilities as blocks rather than creating a second, disconnected execution system.
+
+## Level 7 — Multi-Agent Systems
+
+Introduce specialized cooperating agents only when workflows genuinely benefit from role separation or parallel execution.
+
+Potential roles:
+
+- researcher/lead finder
+- outreach writer
+- validator
+- analyst
+- domain specialist
+
+Multi-agent orchestration should improve measurable quality, speed, reliability, or cost—not exist for appearance.
+
+## Level 8 — Buddy Orchestrator
+
+Buddy becomes the platform-wide orchestration layer after DreamCo has multiple proven bots/systems that need coordinated routing.
+
+Long-term Buddy responsibilities may include:
+
+- task classification and routing
+- permission and human-approval enforcement
+- workload distribution
+- health and performance monitoring
+- cost/resource awareness
+- cross-bot workflow orchestration
+- selecting Lite versus Super execution paths
+
+## Super System Upgrade Triggers
+
+A Lite System may become a Super System when evidence shows that the simpler architecture is a constraint. Triggers can include:
+
+- sustained high workload
+- repeated queue/backlog pressure
+- workflows that benefit materially from parallel processing
+- reliability requirements beyond the Lite implementation
+- multiple clients requiring isolation
+- long-running tasks that require durable orchestration
+- measurable need for autoscaling or distributed workers
+
+Potential Super capabilities include:
+
+- multi-tenant isolated worker pools
+- durable queues
+- parallel execution
+- workflow checkpointing/resume
+- advanced observability
+- targeted auto-repair/retry policies
+- horizontally scalable workers
+
+These are upgrade options, not default requirements.
+
+## Repository Scanner — Later Gate
+
+A repository-wide scanner becomes useful only after the Lite System template and upgrade criteria are proven.
+
+Future scanner responsibilities may include:
+
+- inventorying bots and capabilities
+- detecting duplicate or missing dependencies
+- identifying disconnected integrations
+- reading usage/health metadata
+- recommending Lite/System/Super status
+- identifying candidates for consolidation or retirement
+
+The scanner should initially **recommend** changes rather than automatically modifying every bot.
+
+## Anti-Drift Rules
+
+1. Do not build v2 before v1 produces evidence.
+2. Do not attach Lite Systems globally before the template is proven.
+3. Do not build a visual builder before users need workflow customization.
+4. Do not introduce distributed infrastructure before workload requires it.
+5. Do not make Buddy responsible for systems that are not yet reliable independently.
+6. Prefer measurable user value over capability count.
+
+## Long-Term Architecture
+
+The intended end state remains ambitious:
+
+- independently useful bots;
+- proven bots upgraded into Lite Systems;
+- high-demand Lite Systems upgraded into Super Systems;
+- Buddy coordinating the full ecosystem.
+
+The difference is sequencing: **prove → upgrade → template → scale → orchestrate.**


### PR DESCRIPTION
## What changed

Adds a focused DreamCo Lite planning package based on the decisions from the current product strategy discussion:

- `docs/dreamco-lite/DREAMCO_LITE_MVP.md`
  - locks the MVP to 2 bots, 1 UI, 5-day cycle
  - defines Money Bot v1 and Debug Bot v1
  - defines single-page UI requirements
  - defines acceptance criteria and explicit scope exclusions
- `docs/dreamco-lite/PROOF_MODE.md`
  - defines three real-world validation scenarios
  - adds lead/message/actionability scorecards
  - makes Proof Mode the gate before Money Bot v2
- `docs/dreamco-lite/UPGRADE_LADDER.md`
  - documents the evidence-based path from Lite → Lite System → workflow intelligence → visual builder → multi-agent → Buddy
  - defines Super System upgrade triggers
  - keeps the future repository scanner recommendation-first rather than auto-modifying every bot

## Why

DreamCo's long-term architecture is large. These docs prevent the MVP from drifting into repo-wide automation before the first user-value workflow is proven. The sequencing is now explicit: **prove → upgrade → template → scale → orchestrate**.

## Impact

Documentation only. No runtime behavior, bot code, workflows, dependencies, or production configuration are changed by this PR.

## Validation

Verified the locked MVP document exists on the branch after commit and contains the intended 2-bot / 1-UI / 5-day scope.
