### PR TITLE
Add DreamPayments core and competitive benchmark

### DIFF
--- a/DreamPayments/README.md
+++ b/DreamPayments/README.md
@@ -1,0 +1,33 @@
+# DreamPayments
+
+DreamPayments is Buddy's processor-neutral payment orchestration layer. DreamCo may offer the core software at $0/month while regulated payment-rail, processor, interchange, acquiring, network, banking, payout, chargeback, and compliance costs remain explicit and are never represented as free unless they actually are.
+
+## Product goal
+
+Compete on software capability with Stripe, Square, and bank merchant-processing platforms while differentiating through Buddy AI orchestration, processor routing, statement auditing, dispute assistance, revenue recovery, and unified DreamCo workflows.
+
+## Core principles
+
+- Never store raw CVV in DreamCo databases.
+- Prefer tokenized payment-method references from PCI-compliant providers.
+- Require merchant configuration and approval for routing and pricing policies.
+- Never claim 0% processing unless all underlying payment costs are genuinely covered by a lawful, disclosed model.
+- Treat cash discount, dual pricing, convenience fees, and surcharges as distinct programs.
+- Require authorization and audit logs for refunds, payout destination changes, dispute submissions, and live routing-policy changes.
+
+## Initial components
+
+- `gateway.py` processor-neutral interface and sandbox adapter.
+- `router.py` merchant-controlled routing policy engine.
+- `fee_auditor.py` effective-rate and fee analysis.
+- `benchmark.py` 30-capability competitive benchmark model.
+- `pricing.py` $0/month core software policy.
+- `SECURITY.md` live-payment security baseline.
+
+## Buddy workflow
+
+DreamSalesPro -> invoice/payment request -> DreamPayments -> provider adapter -> settlement/reconciliation -> DreamFinance -> DreamData -> Buddy recommendations.
+
+## Go-live rule
+
+Real-money capability requires an approved processor/acquirer/PayFac partner, compliant merchant onboarding, tokenization, secrets management, PCI-scoped architecture, authorization controls, audit logging, monitoring, dispute/refund procedures, and successful sandbox/live certification where applicable.

--- a/DreamPayments/README.md
+++ b/DreamPayments/README.md
@@ -28,6 +28,10 @@ Compete on software capability with Stripe, Square, and bank merchant-processing
 
 DreamSalesPro -> invoice/payment request -> DreamPayments -> provider adapter -> settlement/reconciliation -> DreamFinance -> DreamData -> Buddy recommendations.
 
+## Public-sector connection
+
+DreamPayments may support authorized government payment collection, invoicing, grant administration, procurement payments, fees, and reconciliation as part of Buddy Public Development. It must not bypass public-finance controls, procurement rules, authorization requirements, or applicable law.
+
 ## Go-live rule
 
 Real-money capability requires an approved processor/acquirer/PayFac partner, compliant merchant onboarding, tokenization, secrets management, PCI-scoped architecture, authorization controls, audit logging, monitoring, dispute/refund procedures, and successful sandbox/live certification where applicable.

--- a/DreamPayments/SECURITY.md
+++ b/DreamPayments/SECURITY.md
@@ -1,0 +1,13 @@
+# DreamPayments Security Baseline
+
+DreamPayments must treat payment credentials as high-risk regulated data.
+
+- Never accept or persist raw CVV.
+- Avoid storing raw PAN; use provider tokenization, hosted fields, or certified terminal SDKs.
+- Encrypt secrets using the deployment platform's secret manager; never commit keys.
+- Require idempotency keys for money-moving API calls.
+- Require explicit authorization for refunds, payout destination changes, dispute submissions, and live routing changes.
+- Maintain append-only audit events for sensitive operations.
+- Separate sandbox and live credentials and prevent accidental cross-mode use.
+- Add rate limits, fraud/velocity rules, webhook signature verification, replay protection, and least-privilege service credentials before live payments.
+- Complete PCI scope review and processor certification before claiming production readiness.

--- a/DreamPayments/__init__.py
+++ b/DreamPayments/__init__.py
@@ -1,0 +1,12 @@
+"""DreamPayments: processor-neutral payment orchestration for Buddy."""
+
+from .gateway import PaymentGateway, PaymentRequest, PaymentResult, SandboxProcessor
+from .router import PaymentRouter, RoutingCandidate, RoutingPolicy
+from .fee_auditor import FeeAudit, audit_statement
+from .pricing import DreamPaymentsPlan, core_plan
+
+__all__ = [
+    "PaymentGateway", "PaymentRequest", "PaymentResult", "SandboxProcessor",
+    "PaymentRouter", "RoutingCandidate", "RoutingPolicy",
+    "FeeAudit", "audit_statement", "DreamPaymentsPlan", "core_plan",
+]

--- a/DreamPayments/benchmark.py
+++ b/DreamPayments/benchmark.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+TOP_CAPABILITIES = (
+    "online_card_payments", "in_person_pos", "tap_to_pay", "payment_links", "invoices",
+    "recurring_billing", "subscriptions", "marketplace_split_payments", "developer_api",
+    "webhooks", "refunds", "disputes_chargebacks", "fraud_detection", "inventory",
+    "customer_crm", "employee_management", "multi_location", "digital_wallets",
+    "fast_deposits", "business_banking", "card_issuing", "international_payments",
+    "processor_routing", "statement_fee_auditing", "ai_dispute_assistance",
+    "ai_revenue_recovery", "ai_payment_assistant", "reconciliation", "analytics",
+    "sandbox_testing",
+)
+
+
+@dataclass(frozen=True)
+class CapabilityScore:
+    provider: str
+    capability: str
+    score: int  # 0 missing, 1 partial, 2 strong
+    evidence: str = ""
+
+
+def buddy_target_matrix() -> list[CapabilityScore]:
+    """Target-state matrix; targets are not production claims."""
+    return [
+        CapabilityScore("Buddy", capability, 2, "DreamPayments target; verify in CI before production-ready")
+        for capability in TOP_CAPABILITIES
+    ]
+
+
+def coverage(scores: list[CapabilityScore], provider: str) -> float:
+    values = [s.score for s in scores if s.provider == provider]
+    return 0.0 if not values else sum(values) / (2 * len(values)) * 100

--- a/DreamPayments/fee_auditor.py
+++ b/DreamPayments/fee_auditor.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+
+
+@dataclass(frozen=True)
+class FeeAudit:
+    card_sales: Decimal
+    total_processing_fees: Decimal
+    effective_rate_percent: Decimal
+    fixed_monthly_fees: Decimal = Decimal("0")
+    equipment_fees: Decimal = Decimal("0")
+    other_fees: Decimal = Decimal("0")
+
+
+def audit_statement(card_sales: Decimal, total_processing_fees: Decimal, *, fixed_monthly_fees: Decimal = Decimal("0"), equipment_fees: Decimal = Decimal("0"), other_fees: Decimal = Decimal("0")) -> FeeAudit:
+    if card_sales <= 0:
+        raise ValueError("card_sales must be greater than zero")
+    if min(total_processing_fees, fixed_monthly_fees, equipment_fees, other_fees) < 0:
+        raise ValueError("fee values cannot be negative")
+    rate = (total_processing_fees / card_sales * Decimal("100")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return FeeAudit(card_sales, total_processing_fees, rate, fixed_monthly_fees, equipment_fees, other_fees)

--- a/DreamPayments/gateway.py
+++ b/DreamPayments/gateway.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Protocol
+from uuid import uuid4
+
+
+@dataclass(frozen=True)
+class PaymentRequest:
+    merchant_id: str
+    amount: Decimal
+    currency: str = "USD"
+    payment_method_token: str = ""
+    idempotency_key: str = ""
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not self.merchant_id:
+            raise ValueError("merchant_id is required")
+        if self.amount <= 0:
+            raise ValueError("amount must be greater than zero")
+        if len(self.currency) != 3:
+            raise ValueError("currency must be a 3-letter code")
+        if not self.payment_method_token:
+            raise ValueError("tokenized payment method is required; raw card data is not accepted")
+
+
+@dataclass(frozen=True)
+class PaymentResult:
+    payment_id: str
+    processor: str
+    status: str
+    amount: Decimal
+    currency: str
+    processor_reference: str | None = None
+
+
+class PaymentGateway(Protocol):
+    name: str
+    def authorize_and_capture(self, request: PaymentRequest) -> PaymentResult: ...
+    def refund(self, payment_id: str, amount: Decimal | None = None) -> PaymentResult: ...
+
+
+class SandboxProcessor:
+    """Non-networked adapter for tests and demos. Never processes a real card."""
+
+    name = "dream-sandbox"
+
+    def __init__(self) -> None:
+        self._payments: dict[str, PaymentResult] = {}
+
+    def authorize_and_capture(self, request: PaymentRequest) -> PaymentResult:
+        request.validate()
+        payment_id = f"dmp_{uuid4().hex}"
+        result = PaymentResult(
+            payment_id=payment_id,
+            processor=self.name,
+            status="succeeded",
+            amount=request.amount,
+            currency=request.currency.upper(),
+            processor_reference=f"sandbox_{uuid4().hex[:16]}",
+        )
+        self._payments[payment_id] = result
+        return result
+
+    def refund(self, payment_id: str, amount: Decimal | None = None) -> PaymentResult:
+        original = self._payments[payment_id]
+        refund_amount = original.amount if amount is None else amount
+        if refund_amount <= 0 or refund_amount > original.amount:
+            raise ValueError("invalid refund amount")
+        return PaymentResult(
+            payment_id=f"dmr_{uuid4().hex}",
+            processor=self.name,
+            status="refunded",
+            amount=refund_amount,
+            currency=original.currency,
+            processor_reference=f"sandbox_refund_{uuid4().hex[:12]}",
+        )

--- a/DreamPayments/pricing.py
+++ b/DreamPayments/pricing.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class DreamPaymentsPlan:
+    name: str
+    monthly_software_fee: Decimal
+    payment_rail_costs_included: bool
+    description: str
+
+
+def core_plan() -> DreamPaymentsPlan:
+    return DreamPaymentsPlan(
+        name="Buddy Pay Core",
+        monthly_software_fee=Decimal("0.00"),
+        payment_rail_costs_included=False,
+        description=(
+            "$0/month DreamCo software layer. Processor, interchange, network, banking, "
+            "chargeback, payout, and regulated third-party costs remain transparent and separate."
+        ),
+    )

--- a/DreamPayments/router.py
+++ b/DreamPayments/router.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class RoutingCandidate:
+    processor: str
+    estimated_cost: Decimal
+    reliability_score: Decimal
+    latency_ms: int
+    available: bool = True
+
+
+@dataclass(frozen=True)
+class RoutingPolicy:
+    strategy: str = "balanced"  # balanced | lowest_cost | highest_reliability | lowest_latency
+    minimum_reliability: Decimal = Decimal("0.995")
+    allowed_processors: tuple[str, ...] = ()
+
+
+class PaymentRouter:
+    """Merchant-policy router. It recommends and routes only within merchant-approved controls."""
+
+    def choose(self, candidates: list[RoutingCandidate], policy: RoutingPolicy) -> RoutingCandidate:
+        eligible = [
+            c for c in candidates
+            if c.available
+            and c.reliability_score >= policy.minimum_reliability
+            and (not policy.allowed_processors or c.processor in policy.allowed_processors)
+        ]
+        if not eligible:
+            raise RuntimeError("no eligible payment processors for this merchant policy")
+        if policy.strategy == "lowest_cost":
+            return min(eligible, key=lambda c: (c.estimated_cost, -c.reliability_score, c.latency_ms))
+        if policy.strategy == "highest_reliability":
+            return max(eligible, key=lambda c: (c.reliability_score, -c.estimated_cost, -c.latency_ms))
+        if policy.strategy == "lowest_latency":
+            return min(eligible, key=lambda c: (c.latency_ms, c.estimated_cost))
+        if policy.strategy != "balanced":
+            raise ValueError(f"unsupported routing strategy: {policy.strategy}")
+        return sorted(eligible, key=lambda c: (-c.reliability_score, c.estimated_cost, c.latency_ms))[0]

--- a/config/public_development_capabilities.json
+++ b/config/public_development_capabilities.json
@@ -1,0 +1,33 @@
+{
+  "system": "Buddy Public Development",
+  "version": 1,
+  "jurisdictions": ["town", "village", "city", "county", "tribal_government", "state", "territory", "region", "country"],
+  "domains": [
+    "economic_development", "small_business", "workforce", "housing", "transportation",
+    "water_wastewater_stormwater", "energy", "broadband", "public_safety", "emergency_management",
+    "public_health", "education", "childcare_youth_seniors", "agriculture_food", "parks_recreation",
+    "tourism_arts_culture", "environment_resilience", "public_finance", "procurement", "government_operations",
+    "civic_engagement", "cybersecurity_digital_government", "land_use_zoning", "asset_management",
+    "trade_investment", "innovation_ecosystem", "public_private_partnerships", "grants_funding",
+    "peer_benchmarking", "scenario_modeling", "performance_management"
+  ],
+  "workflow": [
+    "profile_jurisdiction", "identify_gaps_and_strengths", "benchmark_peers", "rank_opportunities",
+    "discover_funding", "design_projects", "compose_task_team", "track_dependencies_and_approvals",
+    "preserve_evidence", "measure_outcomes", "continuously_rescore"
+  ],
+  "evidence_states": ["VERIFIED", "ESTIMATED", "STALE", "MISSING", "TARGET_ONLY"],
+  "approval_gates": [
+    "public_spending", "procurement_award", "contract_execution", "regulatory_submission",
+    "enforcement_action", "benefits_determination", "resident_record_change", "binding_policy_change"
+  ],
+  "principles": {
+    "recommendations_are_not_adopted_policy": true,
+    "human_authorization_for_consequential_actions": true,
+    "authoritative_sources_for_high_stakes_decisions": true,
+    "explainable_scoring": true,
+    "protected_characteristics_not_used_for_adverse_targeting": true,
+    "auditability_and_provenance_required": true,
+    "public_welfare_over_revenue_only_optimization": true
+  }
+}

--- a/config/real_estate_development_capabilities.json
+++ b/config/real_estate_development_capabilities.json
@@ -1,0 +1,43 @@
+{
+  "system": "Buddy Real Estate Development",
+  "version": 1,
+  "segments": ["residential", "commercial"],
+  "residential_property_types": [
+    "single_family", "duplex_triplex_fourplex", "multifamily", "condominium", "townhome",
+    "affordable_housing", "senior_housing", "student_housing", "manufactured_housing",
+    "build_to_rent", "mixed_income", "subdivision"
+  ],
+  "commercial_property_types": [
+    "retail", "office", "industrial", "warehouse_logistics", "hospitality", "medical_office",
+    "life_science", "data_center", "self_storage", "mixed_use", "entertainment", "restaurant",
+    "automotive", "land_development", "special_purpose"
+  ],
+  "lifecycle": [
+    "market_discovery", "site_selection", "due_diligence", "zoning_land_use", "highest_best_use",
+    "feasibility_proforma", "acquisition", "capital_stack", "incentives_funding", "entitlements_permits",
+    "design_coordination", "construction_estimating", "procurement", "construction_monitoring",
+    "lease_up_sales", "property_operations", "maintenance_capex", "revenue_optimization",
+    "expense_optimization", "refinance_disposition", "portfolio_optimization", "tax_insurance_utilities",
+    "energy_resilience", "distressed_turnaround", "adaptive_reuse", "community_impact",
+    "deal_room", "performance_tracking", "continuous_benchmarking"
+  ],
+  "analysis_metrics": [
+    "purchase_price", "total_project_cost", "loan_to_cost", "loan_to_value", "debt_service",
+    "dscr", "noi", "cap_rate", "cash_on_cash", "irr", "equity_multiple", "break_even_occupancy",
+    "rent_per_unit_or_sf", "operating_expense_ratio", "stabilized_value", "development_yield",
+    "profit_margin", "refinance_proceeds", "sensitivity_analysis"
+  ],
+  "evidence_states": ["VERIFIED", "ESTIMATED", "USER_PROVIDED", "STALE", "TARGET_ONLY"],
+  "approval_gates": [
+    "binding_offer", "purchase_contract", "sale_contract", "lease_execution", "loan_application",
+    "funds_transfer", "contractor_award", "public_submission", "tenant_adverse_action"
+  ],
+  "principles": {
+    "fair_housing_required": true,
+    "protected_characteristics_not_used_for_steering_or_adverse_decisions": true,
+    "licensed_professional_review_when_required": true,
+    "no_fabricated_comps_or_documents": true,
+    "human_authorization_for_binding_actions": true,
+    "auditability_and_provenance_required": true
+  }
+}

--- a/docs/dreampayments_benchmark.md
+++ b/docs/dreampayments_benchmark.md
@@ -1,0 +1,60 @@
+# DreamPayments Competitive Benchmark
+
+This is a benchmark specification, not a claim that every target is production-ready.
+
+## Benchmark peers
+
+- Stripe: APIs, subscriptions, marketplace payments, global payments, developer tooling, fraud/risk, issuing.
+- Square: POS, Tap to Pay, retail workflows, invoices, inventory, CRM, small-business usability.
+- Bank merchant processing: settlement, banking integration, relationship-based merchant services, deposits, support.
+- Buddy / DreamPayments: target is equivalent software coverage plus processor-neutral orchestration and AI automation.
+
+## 30 capability scorecard
+
+Use 0 = missing, 1 = partial, 2 = strong. Every Buddy score needs automated tests, integration evidence, or telemetry before being promoted from target to verified.
+
+1. Online card payments
+2. In-person POS
+3. Tap to Pay
+4. Payment links
+5. Invoices
+6. Recurring billing
+7. Subscriptions
+8. Marketplace/split payments
+9. Developer APIs
+10. Webhooks
+11. Refunds
+12. Disputes/chargebacks
+13. Fraud detection
+14. Inventory
+15. Customer CRM
+16. Employee management
+17. Multi-location
+18. Digital wallets
+19. Fast deposits
+20. Business banking
+21. Card issuing
+22. International payments
+23. Processor routing
+24. Statement fee auditing
+25. AI dispute assistance
+26. AI revenue recovery
+27. AI payment assistant
+28. Reconciliation
+29. Analytics
+30. Sandbox testing
+
+## Buddy differentiation requirements
+
+- Processor-neutral adapter layer.
+- Merchant-controlled routing by cost, reliability, latency, geography, payment method, and risk.
+- Fee Auditor for effective-rate and statement-cost analysis.
+- Buddy workflows for invoices, links, refunds, dispute evidence, and reporting with authorization gates.
+- Unified DreamSalesPro -> DreamPayments -> DreamFinance -> DreamData -> Buddy workflow.
+- $0/month core DreamCo software option with third-party rail costs disclosed separately.
+- ComplianceGuard preventing raw CVV storage and misleading free-processing claims.
+- Continuous status labels: VERIFIED, PARTIAL, DISCONNECTED, TARGET-ONLY.
+
+## Production verification gates
+
+A capability is not production-ready because a class or UI exists. Real-money processing requires approved regulated partners, compliant merchant onboarding, tokenization, secrets management, PCI-scoped architecture, authorization controls, audit logging, monitoring, incident response, dispute/refund procedures, and sandbox/live certification where applicable.

--- a/docs/public_development/BUDDY_PUBLIC_DEVELOPMENT.md
+++ b/docs/public_development/BUDDY_PUBLIC_DEVELOPMENT.md
@@ -1,0 +1,114 @@
+# Buddy Public Development System
+
+Buddy should be able to help cities, towns, villages, counties, tribal governments, states, territories, regions, and countries improve themselves across economic, civic, infrastructure, social, environmental, and operational dimensions.
+
+This is a planning, analysis, coordination, and decision-support capability. Buddy must not impersonate public officials, make binding governmental decisions without authority, award contracts, move public money, submit regulated filings, or represent policy as legally adopted without the required human/public process.
+
+## Core development domains
+
+Buddy should support at least the following domains:
+
+1. Economic development and business attraction
+2. Small-business creation and retention
+3. Workforce development and job creation
+4. Housing supply, affordability, rehabilitation, and homelessness response
+5. Transportation, roads, transit, ports, airports, freight, biking, and walkability
+6. Water, wastewater, stormwater, drainage, flood resilience, and utilities
+7. Energy reliability, efficiency, renewable deployment, and grid modernization
+8. Broadband, digital access, public Wi-Fi, and digital inclusion
+9. Public safety, emergency management, fire, EMS, and disaster recovery
+10. Public health, behavioral health, prevention, and care access
+11. Education, schools, libraries, apprenticeships, and lifelong learning
+12. Child care, youth services, senior services, disability access, and family support
+13. Agriculture, food systems, land use, rural development, and food security
+14. Parks, recreation, trails, tourism, arts, culture, and placemaking
+15. Environmental quality, conservation, climate resilience, and brownfield redevelopment
+16. Public finance, budgeting, procurement, grants, bonds, and capital planning
+17. Tax-base growth, revenue diversification, and cost reduction
+18. Government operations, permitting, licensing, inspections, records, and service delivery
+19. Civic engagement, resident feedback, participatory planning, and transparency
+20. Cybersecurity, identity, data governance, privacy, and resilient digital government
+21. Land-use planning, zoning analysis, development review, and growth scenarios
+22. Infrastructure asset management and preventive maintenance
+23. Trade, exports, investment attraction, logistics, and regional competitiveness
+24. Innovation ecosystems, universities, research, entrepreneurship, and technology transfer
+25. Tourism development and visitor-economy strategy
+26. Public-private partnerships and cross-jurisdiction collaboration
+27. Grant discovery, eligibility screening, application preparation, and compliance tracking
+28. Benchmarking against peer jurisdictions and global best practices
+29. Scenario modeling for population, revenue, housing, jobs, transportation, and infrastructure
+30. Outcome measurement, dashboards, KPIs, audits, and continuous-improvement loops
+
+## Buddy workflow
+
+For any jurisdiction, Buddy should be able to:
+
+1. Build a jurisdiction profile from authoritative public data and user-provided local data.
+2. Identify strengths, weaknesses, urgent risks, underserved populations, infrastructure gaps, and growth opportunities.
+3. Benchmark against comparable jurisdictions.
+4. Create a ranked opportunity portfolio by impact, cost, feasibility, time-to-value, equity, resilience, and legal authority.
+5. Search for relevant grants, programs, incentives, public-private funding, and financing mechanisms when live research is available.
+6. Produce project concepts, budgets, timelines, staffing models, procurement plans, and measurable outcomes.
+7. Create department-specific implementation teams and task-scoped sub-bots.
+8. Track dependencies, approvals, public-meeting requirements, permits, contracts, and funding conditions.
+9. Maintain a transparent evidence trail for assumptions, sources, estimates, and decisions.
+10. Re-score the plan as conditions change.
+
+## Public Development Council
+
+Buddy should compose task-specific sub-bot teams from roles such as:
+
+- Economic Development Bot
+- Grants & Funding Bot
+- Infrastructure Planner
+- Housing Strategy Bot
+- Workforce Development Bot
+- Transportation Planner
+- Public Finance Bot
+- Procurement & Contracting Bot
+- Resilience & Disaster Bot
+- Public Health Planner
+- Education & Skills Bot
+- Small Business Growth Bot
+- Tourism & Placemaking Bot
+- Data & Benchmark Bot
+- GIS / Spatial Analysis Bot
+- Policy Research Bot
+- Legal/Compliance Review Bot
+- Community Engagement Bot
+- Equity & Accessibility Review Bot
+- Cybersecurity & Digital Government Bot
+- Environmental Planning Bot
+- Agriculture & Rural Development Bot
+- International Trade & Investment Bot
+- KPI / Performance Management Bot
+
+Buddy should create or merge specialist sub-bots only when the gap is real, avoid duplicate permanent bots, and preserve a single accountable owner for each workstream.
+
+## Government-specific safeguards
+
+- Clearly distinguish recommendations from adopted policy.
+- Use authoritative and current legal/regulatory sources for high-stakes public decisions.
+- Require human authorization for spending, procurement awards, contracts, public submissions, enforcement, benefits determinations, and changes to resident records.
+- Do not optimize solely for revenue when public welfare, rights, safety, accessibility, or equity are materially affected.
+- Do not rank or target residents using protected characteristics for adverse treatment.
+- Preserve auditability, source provenance, public-record considerations, retention rules, and privacy constraints.
+- Flag uncertainty, missing data, conflicts of interest, and assumptions.
+- Prefer transparent scoring and explainable recommendations for consequential public-sector decisions.
+
+## Jurisdiction modes
+
+Buddy should adapt its planning scale:
+
+- Town/Village mode: limited staff, shared services, grants, roads, utilities, housing, downtown development.
+- City mode: departments, neighborhoods, transit, public safety, permitting, capital projects, economic development.
+- County mode: human services, courts, public health, highways, rural services, emergency management, regional coordination.
+- State mode: statewide policy, agencies, workforce, transportation, education, healthcare, economic development, grants to local governments.
+- Tribal government mode: sovereignty-aware planning, tribal law, federal/tribal programs, land and cultural priorities.
+- Country mode: national infrastructure, trade, industrial policy, health, education, fiscal capacity, energy, digital government, regional development, and international partnerships.
+
+## Development scorecard
+
+Buddy should maintain a scorecard with evidence-backed status for economy, jobs, household income, poverty, housing, business formation, infrastructure, transportation, safety, health, education, digital access, environment, fiscal health, government service quality, resilience, inclusion, innovation, and resident satisfaction.
+
+Every metric should be labeled VERIFIED, ESTIMATED, STALE, MISSING, or TARGET-ONLY so projections are never confused with measured results.

--- a/docs/real_estate/BUDDY_REAL_ESTATE_DEVELOPMENT.md
+++ b/docs/real_estate/BUDDY_REAL_ESTATE_DEVELOPMENT.md
@@ -1,0 +1,196 @@
+# Buddy Real Estate Development System
+
+Buddy should support the full lifecycle of residential and commercial real estate development, ownership, investment, brokerage support, property operations, redevelopment, and portfolio strategy.
+
+This is a planning, analysis, coordination, and decision-support system. Buddy must not practice law, appraise property as a licensed appraiser where licensure is required, make lending decisions on behalf of regulated lenders without authorization, discriminate in housing, misrepresent listings, bypass zoning/building rules, or execute binding transactions without authorized human approval.
+
+## Property types
+
+### Residential
+- single-family homes
+- duplexes, triplexes, fourplexes
+- multifamily apartments
+- condominiums
+- townhomes
+- affordable housing
+- senior housing
+- student housing
+- manufactured housing
+- build-to-rent communities
+- mixed-income developments
+- residential subdivisions
+
+### Commercial
+- retail
+- office
+- industrial
+- warehouse/logistics
+- hospitality
+- medical office
+- life science
+- data centers
+- self-storage
+- mixed-use
+- entertainment
+- restaurants
+- automotive
+- land development
+- special-purpose properties
+
+## Core lifecycle
+
+1. Market discovery and demand analysis
+2. Site selection and parcel screening
+3. Ownership/title-data intake and due diligence coordination
+4. Zoning and land-use review
+5. Highest-and-best-use scenario analysis
+6. Feasibility and pro forma modeling
+7. Acquisition strategy
+8. Financing and capital-stack planning
+9. Incentives, TIF, grants, tax credits, and public-private funding research
+10. Entitlements, permitting, and approval tracking
+11. Architecture, engineering, and design coordination
+12. Construction estimating and procurement planning
+13. Contractor/vendor comparison
+14. Construction schedule and risk monitoring
+15. Lease-up, sales, preleasing, and go-to-market planning
+16. Property management and tenant operations
+17. Maintenance and capital-expenditure planning
+18. Rent/revenue optimization with legal/fair-housing safeguards
+19. Expense benchmarking and cost reduction
+20. Refinance, recapitalization, disposition, or redevelopment strategy
+21. Portfolio optimization and geographic diversification
+22. Tax, insurance, utilities, and operating-cost analysis
+23. ESG, energy efficiency, resilience, and retrofit planning
+24. Distressed-property and turnaround analysis
+25. Adaptive reuse and redevelopment
+26. Opportunity-zone and incentive screening where applicable
+27. Community-impact and public-development coordination
+28. Deal-room, document checklist, and approval workflow
+29. KPI dashboards and ongoing asset-performance tracking
+30. Continuous benchmark against comparable assets and markets
+
+## Deal analysis
+
+Buddy should calculate and clearly label assumptions for:
+
+- purchase price
+- closing costs
+- renovation/development costs
+- total project cost
+- loan amount and loan-to-cost
+- loan-to-value
+- interest rate and debt service
+- debt-service coverage ratio
+- net operating income
+- cap rate
+- cash-on-cash return
+- internal rate of return
+- equity multiple
+- break-even occupancy
+- rent per square foot / unit
+- operating expense ratio
+- stabilized value
+- development yield
+- profit margin
+- refinance proceeds
+- sensitivity to rent, vacancy, rates, costs, and exit cap
+
+Buddy must distinguish VERIFIED, ESTIMATED, USER-PROVIDED, STALE, and TARGET-ONLY numbers.
+
+## Residential capabilities
+
+Buddy should help owners, investors, developers, landlords, buyers, sellers, and housing organizations with:
+
+- home search and comparison
+- affordability analysis
+- mortgage scenario comparison
+- repair/renovation planning
+- rental-property underwriting
+- multifamily acquisition analysis
+- rent-roll analysis
+- tenant-turnover cost analysis
+- maintenance planning
+- affordable-housing funding research
+- housing-development feasibility
+- subdivision feasibility
+- new-construction budgeting
+- property-tax and insurance analysis
+- fair-housing-safe tenant workflows
+- vacancy reduction
+- resident-service planning
+- energy-retrofit analysis
+- refinance and sale scenarios
+
+## Commercial capabilities
+
+Buddy should help with:
+
+- site selection
+- tenant demand analysis
+- trade-area analysis
+- traffic/access/logistics review
+- lease-versus-buy analysis
+- NNN / gross / modified-gross lease comparison
+- tenant improvement planning
+- rent-roll and lease-expiration analysis
+- anchor-tenant and co-tenancy risk
+- industrial logistics suitability
+- office utilization and repositioning
+- retail merchandising and tenant mix
+- hotel feasibility
+- medical-office demand
+- redevelopment and adaptive reuse
+- commercial lending package preparation
+- investor memorandum preparation
+- asset-management dashboards
+- disposition and 1031-exchange planning support
+
+## Specialist team
+
+Buddy should be able to compose task-scoped specialist teams from:
+
+- Acquisition Bot
+- Site Selection Bot
+- Market Research Bot
+- Zoning & Entitlement Bot
+- Development Feasibility Bot
+- Pro Forma Bot
+- Capital Stack Bot
+- Lending Comparison Bot
+- Grants/Incentives Bot
+- Construction Cost Bot
+- Contractor Procurement Bot
+- Project Schedule Bot
+- Lease Analysis Bot
+- Property Management Bot
+- Maintenance/CapEx Bot
+- Tax & Insurance Bot
+- Energy/Resilience Bot
+- Affordable Housing Bot
+- Commercial Leasing Bot
+- Residential Leasing Bot
+- Portfolio Strategy Bot
+- Disposition Bot
+- Redevelopment Bot
+- GIS/Parcel Bot
+- Due Diligence Bot
+- Document/Deal Room Bot
+- Compliance/Fair Housing Bot
+- Public Development Coordination Bot
+
+## Public-development connection
+
+Real estate should connect directly to Buddy Public Development. Buddy should help public and private stakeholders evaluate housing supply, downtown redevelopment, industrial parks, commercial corridors, brownfields, vacant land, adaptive reuse, transit-oriented development, tax-base growth, infrastructure requirements, and community impacts.
+
+## Payment connection
+
+DreamPayments may support authorized rent, deposits, invoices, application fees where lawful, contractor payments, property-management collections, and commercial payment workflows through approved regulated payment providers. It must preserve authorization, audit logs, applicable housing/payment rules, and transparent processing costs.
+
+## High-stakes safeguards
+
+- Never use protected characteristics to steer housing opportunities or make adverse tenant/buyer decisions.
+- Fair housing and anti-discrimination rules override optimization goals.
+- Legal, tax, appraisal, engineering, environmental, lending, and title conclusions that require licensed professionals must be labeled for professional verification.
+- Buddy must not fabricate comps, rent rolls, permits, zoning status, environmental results, title status, lender terms, or appraisal values.
+- Binding offers, leases, contracts, loan applications, purchases, sales, and public submissions require authorized human approval.

--- a/tests/test_dream_payments.py
+++ b/tests/test_dream_payments.py
@@ -1,0 +1,50 @@
+from decimal import Decimal
+
+from DreamPayments.benchmark import TOP_CAPABILITIES, buddy_target_matrix, coverage
+from DreamPayments.fee_auditor import audit_statement
+from DreamPayments.gateway import PaymentRequest, SandboxProcessor
+from DreamPayments.pricing import core_plan
+from DreamPayments.router import PaymentRouter, RoutingCandidate, RoutingPolicy
+
+
+def test_sandbox_payment_and_refund():
+    gateway = SandboxProcessor()
+    result = gateway.authorize_and_capture(
+        PaymentRequest(
+            merchant_id="merchant_demo",
+            amount=Decimal("47.50"),
+            payment_method_token="tok_sandbox_only",
+        )
+    )
+    assert result.status == "succeeded"
+    refunded = gateway.refund(result.payment_id)
+    assert refunded.status == "refunded"
+
+
+def test_fee_auditor_effective_rate():
+    audit = audit_statement(Decimal("30000"), Decimal("1050"))
+    assert audit.effective_rate_percent == Decimal("3.50")
+
+
+def test_router_respects_reliability_and_cost():
+    selected = PaymentRouter().choose(
+        [
+            RoutingCandidate("processor-a", Decimal("1.25"), Decimal("0.999"), 180),
+            RoutingCandidate("processor-b", Decimal("1.05"), Decimal("0.998"), 140),
+        ],
+        RoutingPolicy(strategy="lowest_cost"),
+    )
+    assert selected.processor == "processor-b"
+
+
+def test_core_software_plan_is_free_but_rails_are_not_claimed_free():
+    plan = core_plan()
+    assert plan.monthly_software_fee == Decimal("0.00")
+    assert plan.payment_rail_costs_included is False
+
+
+def test_benchmark_tracks_30_payment_capabilities_as_targets():
+    assert len(TOP_CAPABILITIES) == 30
+    scores = buddy_target_matrix()
+    assert coverage(scores, "Buddy") == 100.0
+    assert all("target" in item.evidence.lower() for item in scores)


### PR DESCRIPTION
## What changed

Adds the first DreamPayments foundation for Buddy:

- processor-neutral sandbox payment gateway
- merchant-controlled processor router
- payment-statement fee auditor
- $0/month Buddy Pay Core software pricing guardrail
- 30-capability benchmark model covering Stripe/Square/bank-processing targets
- security and compliance baseline for real-money go-live
- tests for sandbox payments, refunds, routing, fee auditing, pricing disclosures, and benchmark coverage

## Why

DreamCo needs a payments layer that can compete on software capability without falsely claiming that underlying card-network, acquiring, banking, or regulated processing costs are free. This establishes a safe orchestration architecture first, with real providers to be added behind adapters.

## Important boundary

This PR does **not** turn DreamCo into an acquiring bank, card network, or certified processor. Real-money processing remains gated on approved providers/partners, tokenization, PCI scope, onboarding, authorization controls, audit logs, monitoring, and certification.

## Next implementation phases

1. Add approved processor adapters and webhook verification.
2. Add invoices, payment links, subscriptions, POS/Tap-to-Pay integrations, refunds, disputes, reconciliation, and payouts.
3. Add Buddy AI assistants for fee analysis, dispute evidence, revenue recovery, and payment orchestration.
4. Add live benchmark evidence labels: VERIFIED / PARTIAL / DISCONNECTED / TARGET-ONLY.
5. Connect DreamSalesPro -> DreamPayments -> DreamFinance -> DreamData -> Buddy.

## Validation

Branch is 10 commits ahead of main and changes 10 new files. Core unit tests are included in `tests/test_dream_payments.py` for CI to run.