### PR TITLE
Publish every user-facing page on GitHub Pages and attach backend

### DIFF
--- a/.github/workflows/deploy-buddy-pages.yml
+++ b/.github/workflows/deploy-buddy-pages.yml
@@ -2,6 +2,25 @@ name: Deploy Buddy Website
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "website/**"
+      - "client/**"
+      - "shared/**"
+      - "server/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.ts"
+      - "tools/build_buddy_public_site.py"
+      - "tools/build_github_pages_full_coverage.py"
+      - "tools/build_manufacturer_marketplace_catalog.py"
+      - "tools/check_deployment_cost_policy.py"
+      - "tools/generate_buddy_model_router.py"
+      - "tools/check_buddy_model_benchmarks.mjs"
+      - "tools/generate_buddy_distribution_catalog.py"
+      - "tools/generate_repository_test_registry.py"
+      - "config/**"
+      - ".github/workflows/deploy-buddy-pages.yml"
   push:
     branches:
       - main
@@ -10,6 +29,7 @@ on:
       - "website/**"
       - "client/**"
       - "shared/**"
+      - "server/**"
       - "package.json"
       - "package-lock.json"
       - "vite.config.ts"
@@ -30,6 +50,9 @@ permissions:
 concurrency:
   group: buddy-github-pages-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  DREAMCO_PAGES_BACKEND_URL: ${{ vars.DREAMCO_BACKEND_URL || 'https://dreamco-buddy-312632932335.us-central1.run.app' }}
 
 jobs:
   build:
@@ -67,13 +90,20 @@ jobs:
           test -s website/manufacturer-marketplace.html
           test -s website/data/manufacturer-marketplace.json
 
-      - name: Build full React app for GitHub Pages
+      - name: Type-check full frontend and backend
+        run: npm run check
+
+      - name: Build full React app for GitHub Pages and attach backend
+        env:
+          VITE_GITHUB_PAGES: "true"
+          VITE_API_BASE_URL: ${{ env.DREAMCO_PAGES_BACKEND_URL }}
         run: |
           rm -rf website/app dist/public
-          VITE_GITHUB_PAGES=true npx vite build --base=./
+          npx vite build --base=./
           test -s dist/public/index.html
           cp -R dist/public website/app
           test -s website/app/index.html
+          printf '%s\n' "$VITE_API_BASE_URL" > website/app/backend-endpoint.txt
 
       - name: Verify repo-wide public page coverage
         run: |
@@ -95,14 +125,17 @@ jobs:
           node --check website/service-worker.js
 
       - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v6
 
       - name: Upload public website
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v5
         with:
           path: website
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/deploy-buddy-pages.yml
+++ b/.github/workflows/deploy-buddy-pages.yml
@@ -8,7 +8,13 @@ on:
       - buddy-rebuild-v2
     paths:
       - "website/**"
+      - "client/**"
+      - "shared/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.ts"
       - "tools/build_buddy_public_site.py"
+      - "tools/build_github_pages_full_coverage.py"
       - "tools/build_manufacturer_marketplace_catalog.py"
       - "tools/check_deployment_cost_policy.py"
       - "tools/generate_buddy_model_router.py"
@@ -44,6 +50,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: npm
+
+      - name: Install web dependencies
+        run: npm ci --ignore-scripts
 
       - name: Run deployment preflight
         run: |
@@ -56,6 +66,20 @@ jobs:
           python3 tools/build_buddy_public_site.py --check
           test -s website/manufacturer-marketplace.html
           test -s website/data/manufacturer-marketplace.json
+
+      - name: Build full React app for GitHub Pages
+        run: |
+          rm -rf website/app dist/public
+          VITE_GITHUB_PAGES=true npx vite build --base=./
+          test -s dist/public/index.html
+          cp -R dist/public website/app
+          test -s website/app/index.html
+
+      - name: Verify repo-wide public page coverage
+        run: |
+          python3 tools/build_github_pages_full_coverage.py --check
+          test -s website/page-coverage.html
+          test -s website/data/public-page-coverage.json
 
       - name: Check browser JavaScript syntax
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ vite.config.ts.*
 test-results/
 playwright-report/
 .vercel
+.env.local
+.dreamco/

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
-import { Switch, Route, Redirect } from "wouter";
-import { lazy, Suspense, type ComponentType } from "react";
+import { Switch, Route, Redirect, Router as WouterRouter } from "wouter";
+import { useHashLocation } from "wouter/use-hash-location";
+import { lazy, Suspense, type ComponentType, type ReactNode } from "react";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -54,7 +55,7 @@ function wrap(Page: ComponentType, name: string) {
   };
 }
 
-function Router() {
+function AppRoutes() {
   return (
     <Switch>
       <Route path="/" component={wrap(ChatIndexPage, "Chat")} />
@@ -92,15 +93,20 @@ function Router() {
       <Route path="/buddy" component={wrap(BuddyPage, "Buddy Bot")} />
       <Route path="/settings" component={wrap(SettingsPage, "Settings")} />
 
-      {/* Legacy / convenience */}
       <Route path="/chat">
         <Redirect to="/" />
       </Route>
 
-      {/* Fallback */}
       <Route component={NotFound} />
     </Switch>
   );
+}
+
+function PagesRouter({ children }: { children: ReactNode }) {
+  if (import.meta.env.VITE_GITHUB_PAGES === "true") {
+    return <WouterRouter hook={useHashLocation}>{children}</WouterRouter>;
+  }
+  return <>{children}</>;
 }
 
 function App() {
@@ -109,7 +115,9 @@ function App() {
       <TooltipProvider>
         <Toaster />
         <ErrorBoundary pageName="Application">
-          <Router />
+          <PagesRouter>
+            <AppRoutes />
+          </PagesRouter>
         </ErrorBoundary>
       </TooltipProvider>
     </QueryClientProvider>

--- a/client/src/lib/runtimeBackend.ts
+++ b/client/src/lib/runtimeBackend.ts
@@ -1,0 +1,57 @@
+const backendBase = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/$/, "");
+const pagesMode = import.meta.env.VITE_GITHUB_PAGES === "true";
+
+function isRelativeBackendPath(value: string): boolean {
+  return value.startsWith("/api/") || value === "/api" || value.startsWith("/ws") || value.startsWith("/socket");
+}
+
+export function backendUrl(path: string): string {
+  if (!pagesMode || !backendBase || !isRelativeBackendPath(path)) return path;
+  return `${backendBase}${path}`;
+}
+
+export function installBackendBridge(): void {
+  if (!pagesMode || !backendBase || typeof window === "undefined") return;
+
+  const nativeFetch = window.fetch.bind(window);
+  window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (typeof input === "string") {
+      return nativeFetch(backendUrl(input), init);
+    }
+    if (input instanceof URL) {
+      const raw = input.toString();
+      if (input.origin === window.location.origin && isRelativeBackendPath(input.pathname)) {
+        return nativeFetch(new URL(`${input.pathname}${input.search}${input.hash}`, backendBase), init);
+      }
+      return nativeFetch(raw, init);
+    }
+    if (input instanceof Request) {
+      const url = new URL(input.url, window.location.origin);
+      if (url.origin === window.location.origin && isRelativeBackendPath(url.pathname)) {
+        const bridged = new URL(`${url.pathname}${url.search}${url.hash}`, backendBase).toString();
+        return nativeFetch(new Request(bridged, input), init);
+      }
+    }
+    return nativeFetch(input, init);
+  }) as typeof window.fetch;
+
+  const NativeWebSocket = window.WebSocket;
+  class BridgedWebSocket extends NativeWebSocket {
+    constructor(url: string | URL, protocols?: string | string[]) {
+      let target = url.toString();
+      if (typeof url === "string" && isRelativeBackendPath(url)) {
+        const httpUrl = new URL(url, backendBase);
+        httpUrl.protocol = httpUrl.protocol === "https:" ? "wss:" : "ws:";
+        target = httpUrl.toString();
+      }
+      super(target, protocols as string | string[] | undefined);
+    }
+  }
+  window.WebSocket = BridgedWebSocket as typeof WebSocket;
+}
+
+export const backendRuntime = {
+  pagesMode,
+  configured: Boolean(backendBase),
+  baseUrl: backendBase,
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,13 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { installBackendBridge } from "./lib/runtimeBackend";
 import "./index.css";
 
-// In development, unregister any stale service workers to prevent stale cache issues.
-// In production, register the service worker for offline support.
-if ("serviceWorker" in navigator) {
+installBackendBridge();
+
+// GitHub Pages publishes the React client under /app/ and should not register the
+// production root service worker. The static website has its own worker lifecycle.
+if ("serviceWorker" in navigator && import.meta.env.VITE_GITHUB_PAGES !== "true") {
   if (import.meta.env.DEV) {
     navigator.serviceWorker.getRegistrations().then((registrations) => {
       registrations.forEach((r) => r.unregister());

--- a/docs/LAPTOP_CONTROL_HUB.md
+++ b/docs/LAPTOP_CONTROL_HUB.md
@@ -4,7 +4,7 @@ This setup makes a laptop the local DreamCo development and control environment 
 
 ## One-command bootstrap
 
-From Terminal:
+From Terminal after this change is merged to `main`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/DreamCo-Technologies/Dreamcobots/main/tools/bootstrap_dreamco_laptop.sh -o /tmp/bootstrap_dreamco_laptop.sh
@@ -67,4 +67,4 @@ The laptop can run the same backend locally, but the public Pages site should ta
 
 ## Local status report
 
-The bootstrap writes `.dreamco/laptop-status.txt`. The `.dreamco` folder is intended for local machine status only and must not contain secrets or be treated as a cloud credential store.
+The bootstrap writes `.dreamco/laptop-status.txt`. The `.dreamco` folder and `.env.local` are gitignored and intended for local machine state only. They must not be treated as cloud credential stores or committed to Git.

--- a/docs/LAPTOP_CONTROL_HUB.md
+++ b/docs/LAPTOP_CONTROL_HUB.md
@@ -1,0 +1,70 @@
+# DreamCo Laptop Control Hub
+
+This setup makes a laptop the local DreamCo development and control environment without committing credentials to GitHub.
+
+## One-command bootstrap
+
+From Terminal:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DreamCo-Technologies/Dreamcobots/main/tools/bootstrap_dreamco_laptop.sh -o /tmp/bootstrap_dreamco_laptop.sh
+bash /tmp/bootstrap_dreamco_laptop.sh
+```
+
+If the bootstrap change is still on a pull-request branch rather than `main`, clone the repository with GitHub CLI and run the script from that branch instead:
+
+```bash
+gh repo clone DreamCo-Technologies/Dreamcobots ~/Dreamcobots
+cd ~/Dreamcobots
+git fetch origin agent/github-pages-full-page-coverage
+git checkout agent/github-pages-full-page-coverage
+bash tools/bootstrap_dreamco_laptop.sh
+```
+
+## What it connects
+
+- GitHub repository and GitHub CLI
+- local React frontend
+- local Express/Node backend
+- the configured deployed DreamCo backend
+- local `.env.local` configuration
+- Node/npm and Python runtime checks
+- optional Vercel CLI authentication status
+- optional Google Cloud CLI authentication status
+
+## What still requires provider credentials
+
+A local clone cannot manufacture service credentials. Stripe, databases, OpenAI/model providers, Google Maps APIs, Vercel resources, Google Cloud resources, email, storage, and similar external systems require the corresponding user-owned key, OAuth connection, or provider login.
+
+Store these only in `.env.local`, Vercel environment variables, Google Cloud Secret Manager, GitHub Actions secrets/variables, or the relevant provider secret store. Never commit secret values.
+
+## Start DreamCo locally
+
+```bash
+cd ~/Dreamcobots
+set -a
+source .env.local
+set +a
+npm run dev
+```
+
+By default the server listens on port 5000 unless `PORT` is set.
+
+## Verify
+
+```bash
+curl http://localhost:5000/api/health
+npm run check
+npm run test:repository
+gh pr status
+```
+
+## GitHub Pages relationship
+
+GitHub Pages is static hosting. The repository's Pages build publishes the static `website/` system plus the full React app under `/app/`, and the React app forwards backend calls to `VITE_API_BASE_URL`.
+
+The laptop can run the same backend locally, but the public Pages site should target a separately deployed HTTPS backend. Cross-origin access is limited by the backend's configured allowed origins.
+
+## Local status report
+
+The bootstrap writes `.dreamco/laptop-status.txt`. The `.dreamco` folder is intended for local machine status only and must not contain secrets or be treated as a cloud credential store.

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,11 +10,40 @@ const app = express();
 const httpServer = createServer(app);
 const processStartedAt = Date.now();
 
+const defaultAllowedOrigins = [
+  "https://dreamco-technologies.github.io",
+];
+const configuredAllowedOrigins = (process.env.DREAMCO_ALLOWED_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+const allowedOrigins = new Set([...defaultAllowedOrigins, ...configuredAllowedOrigins]);
+
 declare module "http" {
   interface IncomingMessage {
     rawBody: unknown;
   }
 }
+
+function applyCors(req: Request, res: Response, next: NextFunction) {
+  const origin = req.headers.origin;
+  if (origin && allowedOrigins.has(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Vary", "Origin");
+    res.setHeader("Access-Control-Allow-Credentials", "true");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With, Idempotency-Key");
+    res.setHeader("Access-Control-Allow-Methods", "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS");
+  }
+  if (req.method === "OPTIONS") {
+    if (!origin || !allowedOrigins.has(origin)) {
+      return res.status(403).json({ error: "Origin not allowed" });
+    }
+    return res.sendStatus(204);
+  }
+  return next();
+}
+
+app.use(applyCors);
 
 async function initStripe() {
   if (!process.env.STRIPE_SECRET_KEY && !process.env.STRIPE_LIVE_SECRET_KEY) {
@@ -41,6 +70,7 @@ app.get('/api/health', (_req, res) => {
     environment: process.env.NODE_ENV || 'development',
     uptimeSeconds: Math.floor((Date.now() - processStartedAt) / 1000),
     stripeConfigured: Boolean(process.env.STRIPE_SECRET_KEY || process.env.STRIPE_LIVE_SECRET_KEY),
+    allowedOrigins: [...allowedOrigins],
     timestamp: new Date().toISOString(),
   });
 });

--- a/tools/bootstrap_dreamco_laptop.sh
+++ b/tools/bootstrap_dreamco_laptop.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_SLUG="DreamCo-Technologies/Dreamcobots"
+DEFAULT_DIR="$HOME/Dreamcobots"
+WORKDIR="${DREAMCO_DIR:-$DEFAULT_DIR}"
+BACKEND_URL_DEFAULT="https://dreamco-buddy-312632932335.us-central1.run.app"
+
+say() { printf '\n[%s] %s\n' "DreamCo" "$*"; }
+warn() { printf '\n[DreamCo][WARN] %s\n' "$*" >&2; }
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    warn "$1 is required but not installed."
+    return 1
+  fi
+}
+
+say "Checking laptop tools"
+missing=0
+for cmd in git node npm python3 gh; do
+  require_cmd "$cmd" || missing=1
+done
+if [[ "$missing" -ne 0 ]]; then
+  cat <<'TXT'
+Install missing tools first. On macOS with Homebrew, typical commands are:
+  brew install git node python gh
+Then authenticate GitHub with:
+  gh auth login
+This script never prints or stores your tokens in the repository.
+TXT
+  exit 2
+fi
+
+say "Checking GitHub CLI authentication"
+if ! gh auth status >/dev/null 2>&1; then
+  warn "GitHub CLI is not authenticated. Run: gh auth login"
+  exit 3
+fi
+
+if [[ ! -d "$WORKDIR/.git" ]]; then
+  say "Cloning $REPO_SLUG into $WORKDIR"
+  gh repo clone "$REPO_SLUG" "$WORKDIR"
+else
+  say "Using existing clone at $WORKDIR"
+fi
+
+cd "$WORKDIR"
+
+say "Refreshing repository"
+git fetch --all --prune
+CURRENT_BRANCH="$(git branch --show-current || true)"
+if [[ -z "$CURRENT_BRANCH" ]]; then
+  git checkout main
+fi
+if git show-ref --verify --quiet refs/heads/main; then
+  git checkout main >/dev/null 2>&1 || true
+  git pull --ff-only origin main || warn "Local main has changes; skipped forced update."
+fi
+
+say "Preparing local environment file"
+if [[ ! -f .env.local ]]; then
+  if [[ -f .env.example ]]; then
+    cp .env.example .env.local
+    say "Created .env.local from .env.example"
+  else
+    : > .env.local
+    say "Created empty .env.local"
+  fi
+fi
+chmod 600 .env.local || true
+
+set_env_key() {
+  local key="$1"
+  local value="$2"
+  python3 - "$key" "$value" <<'PY'
+from pathlib import Path
+import sys
+key, value = sys.argv[1], sys.argv[2]
+path = Path('.env.local')
+lines = path.read_text().splitlines() if path.exists() else []
+found = False
+out = []
+for line in lines:
+    if line.startswith(key + '='):
+        out.append(f'{key}={value}')
+        found = True
+    else:
+        out.append(line)
+if not found:
+    out.append(f'{key}={value}')
+path.write_text('\n'.join(out).rstrip() + '\n')
+PY
+}
+
+BACKEND_URL="${DREAMCO_BACKEND_URL:-$BACKEND_URL_DEFAULT}"
+set_env_key "VITE_API_BASE_URL" "$BACKEND_URL"
+set_env_key "DREAMCO_ALLOWED_ORIGINS" "http://localhost:5000,http://localhost:5173,https://dreamco-technologies.github.io"
+
+say "Installing Node dependencies"
+npm ci --ignore-scripts
+
+say "Checking repository TypeScript"
+npm run check
+
+say "Testing backend health when reachable"
+if command -v curl >/dev/null 2>&1; then
+  if curl --silent --show-error --fail --max-time 10 "$BACKEND_URL/api/health" >/dev/null; then
+    say "Backend health endpoint is reachable"
+  else
+    warn "Backend is not reachable at $BACKEND_URL yet. Local setup will still work."
+  fi
+fi
+
+say "Checking optional deployment CLIs"
+if command -v vercel >/dev/null 2>&1; then
+  vercel whoami >/dev/null 2>&1 && say "Vercel CLI authenticated" || warn "Vercel CLI installed but not authenticated"
+else
+  warn "Vercel CLI not installed (optional)"
+fi
+if command -v gcloud >/dev/null 2>&1; then
+  gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null | grep -q . \
+    && say "Google Cloud CLI authenticated" \
+    || warn "Google Cloud CLI installed but no active account"
+else
+  warn "Google Cloud CLI not installed (optional)"
+fi
+
+say "Writing local connection report"
+mkdir -p .dreamco
+cat > .dreamco/laptop-status.txt <<EOF
+DreamCo laptop bootstrap completed
+Repository: $WORKDIR
+Backend: $BACKEND_URL
+GitHub CLI: authenticated
+Node: $(node --version)
+npm: $(npm --version)
+Python: $(python3 --version 2>&1)
+Generated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+EOF
+
+cat <<EOF
+
+DreamCo laptop setup is ready.
+
+Repository:
+  $WORKDIR
+
+Start the full local frontend + backend:
+  cd "$WORKDIR"
+  set -a; source .env.local; set +a
+  npm run dev
+
+Run repository checks:
+  npm run test:repository
+
+GitHub status:
+  gh repo view $REPO_SLUG
+  gh pr status
+
+Important:
+- Secrets stay in .env.local or provider secret stores, never in GitHub source.
+- GitHub Pages uses the deployed backend URL; your laptop can use the same backend or the local server.
+- Stripe, databases, model providers, Google APIs, Vercel, and Cloud services only become live when their own credentials are configured.
+EOF

--- a/tools/build_github_pages_full_coverage.py
+++ b/tools/build_github_pages_full_coverage.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Build and validate repo-wide user-facing page coverage for GitHub Pages.
+
+The public Pages artifact has two layers:
+1. `website/*.html` and nested static pages.
+2. The full React client compiled to `website/app/` in GitHub Pages mode.
+
+This script inventories both and writes an evidence manifest plus a human-readable
+coverage page. It intentionally distinguishes static availability from backend
+runtime availability; a static build does not make protected APIs or secrets live.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WEBSITE = ROOT / "website"
+APP_SOURCE = ROOT / "client" / "src" / "App.tsx"
+PAGES_DIR = ROOT / "client" / "src" / "pages"
+APP_BUILD = WEBSITE / "app"
+DATA_FILE = WEBSITE / "data" / "public-page-coverage.json"
+REPORT_FILE = WEBSITE / "page-coverage.html"
+
+LAZY_IMPORT = re.compile(
+    r'const\s+(?P<name>[A-Za-z0-9_]+)\s*=\s*lazy\(\(\)\s*=>\s*import\("@/pages/(?P<path>[^"]+)"\)\);'
+)
+ROUTE_COMPONENT = re.compile(
+    r'<Route\s+path="(?P<route>[^"]+)"\s+component=\{wrap\((?P<component>[A-Za-z0-9_]+),\s*"(?P<label>[^"]+)"\)\}\s*/>'
+)
+ROUTE_BLOCK = re.compile(r'<Route\s+path="(?P<route>[^"]+)"\s*>')
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def normalize_source_path(import_path: str) -> Path:
+    base = PAGES_DIR / import_path
+    candidates = [base.with_suffix(ext) for ext in (".tsx", ".ts", ".jsx", ".js")]
+    candidates.extend([base / f"index{ext}" for ext in (".tsx", ".ts", ".jsx", ".js")])
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def route_link(route: str) -> str:
+    if ":" in route:
+        return "app/#/"
+    if route == "/":
+        return "app/#/"
+    return f"app/#{route}"
+
+
+def collect() -> tuple[dict, list[str]]:
+    errors: list[str] = []
+    source = APP_SOURCE.read_text(encoding="utf-8")
+
+    imports = {m.group("name"): m.group("path") for m in LAZY_IMPORT.finditer(source)}
+    routes = []
+    routed_components: set[str] = set()
+    for match in ROUTE_COMPONENT.finditer(source):
+        component = match.group("component")
+        routed_components.add(component)
+        import_path = imports.get(component)
+        source_path = normalize_source_path(import_path) if import_path else None
+        if import_path is None:
+            errors.append(f"Route component {component} has no lazy page import")
+        elif source_path and not source_path.exists():
+            errors.append(f"Missing page source for {component}: {source_path.relative_to(ROOT)}")
+        route = match.group("route")
+        routes.append({
+            "route": route,
+            "label": match.group("label"),
+            "component": component,
+            "source": source_path.relative_to(ROOT).as_posix() if source_path and source_path.exists() else import_path,
+            "pages_url": route_link(route),
+            "dynamic": ":" in route,
+            "availability": "static_ui_available_backend_may_be_required",
+        })
+
+    convenience_routes = [m.group("route") for m in ROUTE_BLOCK.finditer(source)]
+    explicit_route_paths = {item["route"] for item in routes}
+    for route in convenience_routes:
+        if route not in explicit_route_paths:
+            routes.append({
+                "route": route,
+                "label": "Redirect / convenience route",
+                "component": None,
+                "source": "client/src/App.tsx",
+                "pages_url": route_link(route),
+                "dynamic": ":" in route,
+                "availability": "redirect_or_convenience_route",
+            })
+
+    page_files = sorted(
+        path for path in PAGES_DIR.rglob("*")
+        if path.is_file() and path.suffix in {".tsx", ".ts", ".jsx", ".js"}
+    )
+    imported_files: set[Path] = set()
+    for import_path in imports.values():
+        resolved = normalize_source_path(import_path)
+        if resolved.exists():
+            imported_files.add(resolved.resolve())
+
+    unrouted_sources = []
+    for path in page_files:
+        if path.resolve() not in imported_files:
+            unrouted_sources.append(path.relative_to(ROOT).as_posix())
+
+    # NotFound is imported and intentionally has no explicit path; all other imported pages
+    # must appear in a route component.
+    for component, import_path in imports.items():
+        if component == "NotFound":
+            continue
+        if component not in routed_components:
+            errors.append(f"Imported page {component} ({import_path}) is not bound to an explicit route")
+
+    static_pages = []
+    for path in sorted(WEBSITE.rglob("*.html")):
+        if APP_BUILD in path.parents:
+            continue
+        static_pages.append({
+            "path": path.relative_to(WEBSITE).as_posix(),
+            "source": path.relative_to(ROOT).as_posix(),
+            "pages_url": path.relative_to(WEBSITE).as_posix(),
+        })
+
+    app_index = APP_BUILD / "index.html"
+    app_built = app_index.exists()
+    if not app_built:
+        errors.append("React GitHub Pages build missing: website/app/index.html")
+
+    payload = {
+        "schema": "dreamco.public_page_coverage.v1",
+        "generated_at": utc_now(),
+        "summary": {
+            "static_html_pages": len(static_pages),
+            "react_routes": len(routes),
+            "react_page_source_files": len(page_files),
+            "unrouted_page_source_files": len(unrouted_sources),
+            "app_built": app_built,
+        },
+        "deployment_contract": {
+            "static_site_source": "website/",
+            "react_app_publish_path": "website/app/",
+            "react_pages_mode": "hash routing",
+            "backend_runtime_on_github_pages": False,
+            "note": "Every routed React screen is published as UI. API-, secret-, database-, payment-, or server-dependent operations remain disconnected unless a separately deployed backend is configured.",
+        },
+        "static_pages": static_pages,
+        "react_routes": sorted(routes, key=lambda item: item["route"]),
+        "unrouted_page_sources": unrouted_sources,
+    }
+    return payload, errors
+
+
+def render_report(payload: dict) -> str:
+    summary = payload["summary"]
+    static_rows = "\n".join(
+        f'<tr><td>{html.escape(item["path"])}</td><td><a href="{html.escape(item["pages_url"])}">Open</a></td><td>{html.escape(item["source"])}</td></tr>'
+        for item in payload["static_pages"]
+    )
+    react_rows = "\n".join(
+        f'<tr><td>{html.escape(item["route"])}</td><td>{html.escape(item["label"])}</td><td><a href="{html.escape(item["pages_url"])}">Open UI</a></td><td>{html.escape(str(item["source"]))}</td><td>{html.escape(item["availability"])}</td></tr>'
+        for item in payload["react_routes"]
+    )
+    warning = (
+        "<p class=\"warning\"><strong>Runtime boundary:</strong> GitHub Pages is static. The full React UI is published, but server/API/database/payment controls still require the deployed DreamCo backend and authorized credentials.</p>"
+    )
+    return f'''<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>DreamCo Public Page Coverage</title>
+<style>body{{font-family:system-ui,sans-serif;max-width:1400px;margin:auto;padding:24px;background:#0b1020;color:#eef2ff}}a{{color:#8ab4ff}}table{{width:100%;border-collapse:collapse;margin:18px 0 36px}}th,td{{border:1px solid #334155;padding:8px;text-align:left;vertical-align:top}}th{{background:#172033}}.cards{{display:flex;gap:12px;flex-wrap:wrap}}.card{{background:#172033;padding:12px 16px;border-radius:10px}}.warning{{background:#3b2a12;padding:14px;border-radius:10px}}</style></head>
+<body><h1>DreamCo GitHub Pages — Full Page Coverage</h1>
+<p>Generated {html.escape(payload["generated_at"])} from repository sources.</p>
+<div class="cards"><div class="card"><strong>{summary["static_html_pages"]}</strong><br>static HTML pages</div><div class="card"><strong>{summary["react_routes"]}</strong><br>React routes</div><div class="card"><strong>{summary["react_page_source_files"]}</strong><br>React page source files</div><div class="card"><strong>{summary["unrouted_page_source_files"]}</strong><br>unrouted page files</div></div>
+{warning}
+<h2>React application pages</h2><table><thead><tr><th>Route</th><th>Page</th><th>GitHub Pages</th><th>Source</th><th>Status</th></tr></thead><tbody>{react_rows}</tbody></table>
+<h2>Static website pages</h2><table><thead><tr><th>Page</th><th>GitHub Pages</th><th>Source</th></tr></thead><tbody>{static_rows}</tbody></table>
+</body></html>'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Fail if page coverage is incomplete")
+    args = parser.parse_args()
+
+    payload, errors = collect()
+    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    DATA_FILE.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    REPORT_FILE.write_text(render_report(payload), encoding="utf-8")
+
+    if payload["unrouted_page_sources"]:
+        errors.append("Unrouted page source files: " + ", ".join(payload["unrouted_page_sources"]))
+
+    print(json.dumps(payload["summary"], indent=2))
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1 if args.check else 0
+    print("All discovered user-facing page sources are represented in the GitHub Pages artifact.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
+const githubPagesMode = process.env.VITE_GITHUB_PAGES === "true";
+
 export default defineConfig({
   plugins: [react()],
+  base: githubPagesMode ? "./" : "/",
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "client", "src"),


### PR DESCRIPTION
## What changed

This PR fixes the repository-wide GitHub Pages coverage gap and adds a laptop control-hub bootstrap.

### Full page coverage
- Publishes the existing `website/` static site as before.
- Builds the full React client and publishes it under `website/app/`.
- Uses hash routing in GitHub Pages mode so all React routes can be opened directly under `/app/#/...`.
- Adds a repository-wide page coverage scanner and generated `page-coverage.html` / `data/public-page-coverage.json` evidence.
- Fails the Pages preflight when a discovered React page source is not routed or the app build is missing.

### Backend attachment
- Adds one runtime backend bridge that redirects relative `/api`, `/ws`, and `/socket` frontend traffic to the configured DreamCo backend.
- Pages builds use repository variable `DREAMCO_BACKEND_URL` when configured, otherwise the currently known DreamCo Cloud Run endpoint is used as the default.
- Adds locked-down Express CORS support for `https://dreamco-technologies.github.io` plus optional origins from `DREAMCO_ALLOWED_ORIGINS`.
- Preserves credentials and WebSocket protocol conversion for backend calls.
- Skips the root React service worker in Pages mode so it cannot break the `/app/` deployment.

### Laptop control hub
- Adds `tools/bootstrap_dreamco_laptop.sh` for one-command local setup.
- Verifies GitHub CLI authentication, clone/update state, Node/npm/Python, dependencies, TypeScript, and backend health.
- Creates local `.env.local`, attaches `VITE_API_BASE_URL`, and keeps laptop-only state out of Git.
- Detects optional Vercel and Google Cloud CLI authentication without printing secret values.
- Adds `docs/LAPTOP_CONTROL_HUB.md` with local start and verification commands.
- Adds `.env.local` and `.dreamco/` to `.gitignore`.

### CI / deployment truth
- Pull requests run the full Pages build, TypeScript check, and coverage verification without deploying.
- Pushes to deployment branches still publish the final `website/` artifact.
- GitHub Pages remains static hosting; Node/Express, databases, Stripe secrets, authenticated APIs, WebSockets, and other backend behavior execute on the separately deployed DreamCo backend or locally on the laptop.

## Deployment dependency

The frontend/backend transport is wired in this PR. The deployed backend must run the CORS-enabled revision for cross-origin GitHub Pages API calls to succeed. External providers such as Stripe, databases, model APIs, Google APIs, Vercel, and cloud services still require their own user-authorized credentials or OAuth connections; the bootstrap does not fabricate or expose secrets.