### PR TITLE
Fix TypeScript 7 certification blocker

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "types": ["node", "vite/client"],
     "paths": {
       "@/*": ["./client/src/*"],


### PR DESCRIPTION
## Debug result
The certification run `31731872971` failed at trusted-code static audit because `npm run check` failed with TypeScript 7:

`tsconfig.json(17,5): error TS5102: Option 'baseUrl' has been removed.`

## Fix
Remove the obsolete `baseUrl` compiler option while preserving the existing `paths` aliases.

## Verification
The exact failure was extracted from the uploaded certification artifact, not inferred. The next Actions run must verify `npm run check` and then unlock the downstream certification stages. No passing result is claimed until GitHub reports it.

## Remaining blockers after this fix
The same run also lacked evidence for maximum sandbox, sandbox runtime, production runtime smoke, production verification, and speed/accuracy. Those should be allowed to execute once the trusted-code gate passes.