### PR TITLE
Add Actions recovery, PR scanner, and benchmark health controls

### DIFF
--- a/docs/ACTIONS_RECOVERY_AND_BENCHMARK_DASHBOARD.md
+++ b/docs/ACTIONS_RECOVERY_AND_BENCHMARK_DASHBOARD.md
@@ -1,0 +1,90 @@
+# Actions Recovery, PR Audit & Benchmark Dashboard
+
+## Purpose
+Provide one owner-facing control surface for finding problems, auditing pull requests, repairing approved issues, and measuring current benchmark health.
+
+## Buttons
+
+### 🔎 Find Problems & Bugs
+Run a bounded repository health scan covering:
+- recent failed Actions runs
+- repeated failure fingerprints
+- broken workflow references
+- missing scripts/files
+- dependency/build/type errors
+- security findings
+- stale or conflicting configuration
+- benchmark regressions
+- missing evidence
+- broken Pages/download paths
+
+Every finding must retain its source run, job, step, commit, severity, evidence and status.
+
+### 🔍 Scan Pull Requests
+Audit open PRs for:
+- merge conflicts
+- failing required checks
+- stale branches
+- missing tests
+- missing documentation
+- security/dependency findings
+- changed files without appropriate coverage
+- duplicate or overlapping PR scope
+- unsupported configuration
+- claims that are not backed by evidence
+
+Classify each PR as `healthy`, `review`, `blocked`, `stale`, or `duplicate_candidate`. Never close or merge a PR solely because a scanner recommends it.
+
+### 🛠 Fix Problems
+Create a review branch and generate the smallest repair that addresses an evidence-backed finding. Run targeted tests, dependent regression tests, security checks and relevant benchmarks. Open a PR with the evidence. High-impact or destructive changes remain approval-gated.
+
+### 🔁 Replay Failures
+Re-run only failed jobs/runs that are still relevant. Do not repeatedly replay deterministic failures without a new code/configuration change. Classify infrastructure/flaky failures separately.
+
+### 📊 Benchmark Health
+Show current benchmark evidence as:
+- green = passed on the current measured revision/environment
+- red = failed on the current measured revision/environment
+- yellow = incomplete, stale, or awaiting evidence
+- gray = not executed / not applicable
+
+Historical GitHub failures remain historical. The dashboard must never rewrite them to green. Instead it shows `historical failure → superseded by verified run` when a later run proves the issue resolved.
+
+## Benchmark percentage calculation
+
+`green_pct = green / (green + red) * 100`
+
+`red_pct = red / (green + red) * 100`
+
+Yellow/incomplete is reported separately and is never silently counted as green.
+
+The denominator must identify the benchmark suite, fixture version, model/runtime version, repository commit and evidence timestamp. Percentages without that provenance are not release evidence.
+
+## Recovery state machine
+
+```text
+DISCOVER → FINGERPRINT → CLASSIFY → REPRODUCE → PROPOSE FIX
+                                      ↓
+                                  APPROVAL
+                                      ↓
+                              PATCH → TEST → BENCHMARK
+                                      ↓
+                                  VERIFY
+                                      ↓
+                            PR / RELEASE EVIDENCE
+```
+
+## Truth contract
+
+GitHub Actions history is immutable evidence. The system cannot and should not make old failed runs appear successful. The objective is a green **current verified state**, with historical failures linked to their verified repairs.
+
+A green dashboard requires actual successful GitHub evidence. Planned, skipped, cancelled, stale, or missing runs are not green.
+
+## Efficiency rules
+
+- Prefer targeted checks before full-system certification.
+- Reuse valid evidence until the measured revision/environment changes.
+- Deduplicate identical root causes.
+- Limit parallel work to the repository's configured runner budget.
+- Stop repeated retries after a configurable threshold.
+- Store artifacts and fingerprints so the same failure can be diagnosed without rerunning everything.

--- a/docs/ACTIONS_RECOVERY_BUTTONS.md
+++ b/docs/ACTIONS_RECOVERY_BUTTONS.md
@@ -1,0 +1,23 @@
+# Actions Recovery Controls
+
+The Actions page should expose these controls:
+
+- **Find Problems & Bugs** — scan current workflow evidence, build/configuration failures, security findings, benchmark regressions, broken links and missing evidence.
+- **Scan Pull Requests** — inspect open PRs for conflicts, failed checks, stale branches, missing tests/docs, security findings, duplicate scope and unsupported configuration.
+- **Fix Problems** — create a review branch with the smallest evidence-backed repair. Run targeted verification and open a PR. Do not silently merge.
+- **Replay Failures** — retry only relevant failed jobs/runs. Avoid repeated retries of deterministic failures.
+- **Benchmark Health** — show green/red/yellow/gray with provenance.
+- **Recovery History** — show historical failure, root cause, repair PR, verification run and current status.
+
+## Green-state rule
+Old GitHub failures are immutable history. A green current state means a newer verified run on the relevant revision/environment passed. Historical failures are labeled superseded when appropriate; they are never rewritten.
+
+## Repair lifecycle
+
+`SCAN → FINGERPRINT → CLASSIFY → REPRODUCE → PROPOSE → APPROVE → PATCH → TEST → BENCHMARK → VERIFY → REPORT`
+
+## PR lifecycle
+
+`SCAN PRs → identify blocked/stale/duplicate candidates → explain evidence → propose action → user approval → repair/rebase/update → required checks → merge decision`
+
+The scanner must never close, merge, delete, or rewrite a PR solely from an automated recommendation.

--- a/tools/actions_recovery_dashboard.py
+++ b/tools/actions_recovery_dashboard.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Evidence-first Actions/PR recovery scanner.
+
+This tool reports current health; it never rewrites historical GitHub results.
+Use GitHub's API credentials/environment outside this script when integrating it
+with a live Actions page. Repair operations must create reviewable changes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Literal
+
+Status = Literal["green", "red", "yellow", "gray"]
+
+@dataclass(frozen=True)
+class Finding:
+    category: str
+    severity: str
+    status: Status
+    title: str
+    evidence: str
+    recommended_action: str
+
+
+def benchmark_percentages(results: list[Status]) -> dict[str, float | int]:
+    green = results.count("green")
+    red = results.count("red")
+    measured = green + red
+    return {
+        "green": green,
+        "red": red,
+        "yellow": results.count("yellow"),
+        "gray": results.count("gray"),
+        "measured": measured,
+        "green_pct": round(green / measured * 100, 2) if measured else 0.0,
+        "red_pct": round(red / measured * 100, 2) if measured else 0.0,
+    }
+
+
+def classify_build_failure(title: str, evidence: str) -> Finding:
+    return Finding(
+        category="actions",
+        severity="high",
+        status="red",
+        title=title,
+        evidence=evidence,
+        recommended_action="Reproduce the failure, identify root cause, create the smallest reviewable repair, then rerun targeted verification.",
+    )
+
+
+def dashboard_payload(findings: list[Finding], benchmark_results: list[Status]) -> dict:
+    return {
+        "policy": {
+            "historical_runs_are_immutable": True,
+            "auto_merge": False,
+            "destructive_repairs": False,
+            "green_requires_current_evidence": True,
+        },
+        "benchmarks": benchmark_percentages(benchmark_results),
+        "findings": [asdict(item) for item in findings],
+    }
+
+
+if __name__ == "__main__":
+    # Smoke-test the calculation without claiming repository health.
+    sample = benchmark_percentages(["green", "green", "red", "yellow", "gray"])
+    assert sample["green_pct"] == 66.67
+    assert sample["red_pct"] == 33.33
+    print("Actions recovery scanner self-test: PASS")


### PR DESCRIPTION
Adds the first executable layer of the Actions Recovery system on a dedicated branch.

Included:
- evidence-first recovery scanner with benchmark green/red/yellow/gray calculation
- self-test for benchmark percentage math
- documented Actions page controls for finding bugs, scanning PRs, fixing approved problems, replaying relevant failures, and reviewing recovery history
- explicit rule that historical GitHub failures remain immutable and current green status requires fresh verified evidence
- approval-gated repair/PR lifecycle

This PR does not claim that all Actions workflows are currently green. It provides the foundation for the dashboard and preserves truthful evidence.